### PR TITLE
Fix file explorer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm start          # Dev server at http://localhost:4200
+npm run build      # Production build (output: dist/site_cenca/)
+npm run watch      # Dev build with watch mode
+npm test           # Unit tests (Karma + Jasmine)
+npm run compodoc   # Generate API docs in src/assets/documentation/
+```
+
+To run a single test file:
+
+```bash
+ng test --include='**/my-component.spec.ts'
+```
+
+## Architecture Overview
+
+**Angular 18** app using **standalone components** (no NgModules). Functional routing (`provideRouter`), functional HTTP interceptors, and Angular Signals for modern state management.
+
+The project works with a NODEJS / Express library backend server.
+
+### Key Configuration Files
+
+- **`src/app/backendAdress.ts`** — hardcoded production backend URL (`http://si-10.cen-champagne-ardenne.org:8887/`). Dev URL lives in `src/environments/environment.ts`.
+- **`src/app/app.config.ts`** — root providers: router, HTTP client with auth interceptor, animations.
+- **`src/app/app.routes.ts`** — root routing with lazy-loaded feature routes.
+
+### Feature Modules (lazy-loaded)
+
+| Route | Feature |
+| --- | --- |
+| `/sites` | Main site management (CENCA sites) |
+| `/foncier` | Land/property management |
+| `/parametres` | Admin settings (users, groups) |
+
+### Authentication
+
+- JWT stored in `localStorage`; `src/app/interceptor/auth-token.interceptor.ts` injects it on all requests.
+- `LoginService` exposes `user = signal<User | undefined | null>()` as the auth state source of truth.
+- `isLoggedInGuard` protects all routes except `login`, `reset-password`, and `aide`.
+- On app init/navigation, the guard calls `/auth/me` to rehydrate user state from the token.
+
+### State Management Patterns
+
+- **Angular Signals** — used in `LoginService` for user state and in components for local reactive state.
+- **RxJS BehaviorSubject** — used in `MenuService` (menu items) and `FormService` (form validity).
+
+### Shared Infrastructure
+
+- **`src/app/shared/interfaces/`** — TypeScript interfaces for all API DTOs (`site-geojson.ts`, `geo.ts`, `localisation.ts`, `selector.ts`, etc.).
+- **`src/app/shared/services/`** — `GeoService`, `DocfileService`, `ConfirmationService` (modal dialogs).
+- **`src/app/shared/file-explorator/`** — multi-format file browser (PDF, DOCX via `docx-preview`, images).
+- **`src/app/map/`** — complex Leaflet (`@asymmetrik/ngx-leaflet`) + Turf.js component; handles dynamic tile layers, parcel selection, and GeoJSON rendering for sites, projects, and operations.
+
+### Styling
+
+- Global styles in `src/styles.scss`.
+- Angular Material with a custom indigo-pink theme (`src/app/styles/indigo-pink-custom.css`).
+- All components use SCSS (`.component.scss`).
+
+### Deployment
+
+- Docker support via `Dockerfile` in root.
+- Jenkins webhook: `main` branch → production, `dev` branch → staging.
+- A postinstall script (`scripts/fix-leaflet-fullscreen.js`) patches the Leaflet fullscreen plugin after `npm install`.

--- a/src/app/shared/file-explorator/file-explorator.component.ts
+++ b/src/app/shared/file-explorator/file-explorator.component.ts
@@ -218,7 +218,7 @@ export class FileExploratorComponent {
     this.docfileService.docfiles.forEach((file: any) => {
       if (file.doc_path.split('/').pop() === filename.split('/').pop()) {
         console.log('file.doc_path:', file.doc_path);
-        filename = 'files/photos/' +file.doc_path;
+        filename = `files/${file.doc_path}`;
       }
     });
     console.log('filename:', filename);
@@ -278,19 +278,13 @@ export class FileExploratorComponent {
     }
   }
 
-  getGalerie(filePathList: string[]) {
-    filePathList.forEach((path) => {
-      // Url qui s'adapte en fonction de l'environnement Windows ou Linux
-      // let url = `${this.activeUrl}picts/img?file=${path.split( environment.pathSep ).pop()}&width=200`;
-      let url = `${this.activeUrl}picts/img?file=${path}&width=200`;
-      filePathList.push(url);
-    });
-    console.log('filePathList après ajout des miniatures:', filePathList);
-    this.galerie = filePathList.slice(filePathList.length / 2, undefined);
-    console.log('this.galerie:', this.galerie);
-
-    this.imagePathList = filePathList;
-    console.log('imagePathList:', this.imagePathList);
+  getGalerie(docPaths: string[]) {
+    this.imagePathList = [...docPaths];
+    this.galerie = docPaths.map(
+      (path) => `${this.activeUrl}picts/img?file=${path}&width=200`
+    );
+    console.log('imagePathList (doc_paths):', this.imagePathList);
+    console.log('galerie (thumbnail urls):', this.galerie);
   }
 
   /**
@@ -301,7 +295,7 @@ export class FileExploratorComponent {
     console.log('openImage imagePath:', imagePath);
     const dialogRef = this.dialog.open(ImageViewComponent, {
       data: {
-        images: this.imagePathList?.slice(0, this.imagePathList.length / 2),
+        images: this.imagePathList,
         selected: imagePath,
       }, // <---------------- données injectée au composant
       minWidth: '70vw',
@@ -317,29 +311,23 @@ export class FileExploratorComponent {
   }
 
   deleteImage(imagePath: string) {
-    console.log('imagePath:', imagePath);
-    
-    this.filePathList.forEach((docfile: any) => {
-      console.log('docfile:', docfile);
-      if (docfile === imagePath) {
-        this.docfileService.deleteFile(docfile).subscribe({
-          next: (res) => {
-            console.log('Suppression OK', res);
-            this.updateFolderCounts();
-            this.docfileService
-              .getFilesList(
-                this.selectedFolder as number,
-                this.section,
-                this.referenceId ? this.referenceId : undefined
-              )
-              .then(() => {
-                this.filePathList = this.docfileService.filePathList;
-                this.getGalerie(this.filePathList);
-              });
-          },
-          error: (err) => console.error('Erreur suppression', err),
-        });
-      }
+    console.log('deleteImage doc_path:', imagePath);
+    this.docfileService.deleteFile(imagePath).subscribe({
+      next: (res) => {
+        console.log('Suppression OK', res);
+        this.updateFolderCounts();
+        this.docfileService
+          .getFilesList(
+            this.selectedFolder as number,
+            this.section,
+            this.referenceId ? this.referenceId : undefined
+          )
+          .then(() => {
+            this.filePathList = this.docfileService.filePathList;
+            this.getGalerie(this.filePathList);
+          });
+      },
+      error: (err) => console.error('Erreur suppression', err),
     });
   }
 

--- a/src/app/shared/services/docfile.service.ts
+++ b/src/app/shared/services/docfile.service.ts
@@ -8,7 +8,6 @@ import { SitesService } from '../../sites/sites.service';
 import { Localisation } from '../../shared/interfaces/localisation';
 import {
   HttpClient,
-  HttpParams,
   HttpErrorResponse,
 } from '@angular/common/http';
 
@@ -233,7 +232,7 @@ export class DocfileService {
    * @returns 
    */
   deleteFile(doc_path: string): Observable<ApiResponse> {
-    const url = `${this.activeUrl}sites/delete/files.docs?doc_path=${doc_path}`;
+    const url = `${this.activeUrl}sites/delete/files.docs?doc_path=${encodeURIComponent(doc_path)}`;
     console.log(`lien de suppression : ${url}`);
     console.log('doc_path envoyé :', doc_path);
     return this.http

--- a/src/app/sites/foncier/fon-pmfu/detail-pmfu/STEPPER-MEMO.md
+++ b/src/app/sites/foncier/fon-pmfu/detail-pmfu/STEPPER-MEMO.md
@@ -1,0 +1,78 @@
+# Mémo — Rester sur l'onglet actif après sauvegarde
+
+## Problème de départ
+
+Le composant `DetailPmfuComponent` affiche un formulaire découpé en **3 onglets** (`mat-step`) :
+1. Informations principales
+2. Localisation
+3. Pièces jointes
+
+Après un clic sur « Enregistrer » (`onSubmit()`), le backend répond, le frontend recharge les données via `setupPmfuForm()`, et le stepper Material revenait systématiquement au **premier onglet**, perdant la position de l'utilisateur.
+
+---
+
+## Pourquoi ça se passait ainsi
+
+`setupPmfuForm()` recrée entièrement le `FormGroup` (`this.pmfuForm = ...`). Cette réinitialisation force Angular Material à redessiner le stepper depuis son état par défaut, c'est-à-dire l'index 0.
+
+---
+
+## La solution
+
+Trois ajouts dans `detail-pmfu.component.ts` :
+
+### 1. Importer le type `MatStepper`
+
+```ts
+import { MatStepperModule, MatStepper, StepperOrientation } from '@angular/material/stepper';
+```
+
+`MatStepper` est la classe qui représente l'instance du composant stepper. Sans cet import, TypeScript ne connaît pas la propriété `selectedIndex`.
+
+### 2. Référencer le stepper avec `@ViewChild`
+
+```ts
+@ViewChild('mfuStepper') mfuStepper!: MatStepper;
+```
+
+`#mfuStepper` est la référence template déclarée dans le HTML :
+```html
+<mat-horizontal-stepper [linear]="false" #mfuStepper>
+```
+
+`@ViewChild` permet au composant TypeScript d'accéder directement à l'instance Angular Material du stepper, et donc de lire ou d'écrire son `selectedIndex` (l'index de l'onglet actif, 0 = premier onglet).
+
+### 3. Sauvegarder et restaurer l'index dans `onSubmit()`
+
+```ts
+onSubmit(): void {
+  // Mémoriser l'onglet actif avant toute opération
+  const activeStepIndex = this.mfuStepper?.selectedIndex ?? 0;
+
+  // ... logique de soumission ...
+
+  // Après le rechargement du formulaire, remettre l'onglet actif
+  await this.setupPmfuForm();
+  this.cdr.detectChanges();
+  this.mfuStepper.selectedIndex = activeStepIndex;
+}
+```
+
+- `this.mfuStepper?.selectedIndex` lit l'index de l'onglet affiché au moment du clic (le `?` protège si le stepper n'est pas encore rendu).
+- `?? 0` fournit une valeur par défaut (premier onglet) si la lecture échoue.
+- Après `setupPmfuForm()` et `detectChanges()`, on réassigne `selectedIndex` pour repositionner le stepper.
+
+---
+
+## Pourquoi après `detectChanges()` et non avant
+
+`setupPmfuForm()` recrée le formulaire et émet de nouveaux signaux de changement. `cdr.detectChanges()` force Angular à appliquer ces changements au DOM. Ce n'est qu'**après** cette mise à jour que le stepper existe à nouveau dans sa nouvelle version et accepte une réassignation de `selectedIndex`. Faire le repositionnement avant produirait un effet sans résultat visible.
+
+---
+
+## Fichiers concernés
+
+| Fichier | Modification |
+|---|---|
+| `detail-pmfu.component.ts` | Import `MatStepper`, ajout `@ViewChild`, sauvegarde/restauration de l'index dans `onSubmit()` |
+| `detail-pmfu.component.html` | Aucune modification — `#mfuStepper` était déjà présent sur `<mat-horizontal-stepper>` |

--- a/src/app/sites/foncier/fon-pmfu/detail-pmfu/detail-pmfu.component.ts
+++ b/src/app/sites/foncier/fon-pmfu/detail-pmfu/detail-pmfu.component.ts
@@ -29,7 +29,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, FormsModule, Form } from '
 
 import { Subscription, lastValueFrom } from 'rxjs';
 
-import { MatStepperModule, StepperOrientation,} from '@angular/material/stepper';
+import { MatStepperModule, MatStepper, StepperOrientation,} from '@angular/material/stepper';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -213,6 +213,7 @@ export class DetailPmfuComponent {
   folders$ = this.foldersSubject.asObservable();
   @ViewChild(FileExploratorComponent) fileExplorator!: FileExploratorComponent;
   @ViewChild(MapComponent) mapComponent!: MapComponent;
+  @ViewChild('mfuStepper') mfuStepper!: MatStepper;
   
   communeInsee?: Commune; // Commune chargée dans le formulaire
   communes: Commune[] = [];
@@ -879,6 +880,7 @@ export class DetailPmfuComponent {
    * ou si la liste de fichiers a changé
    */
   onSubmit(): void {
+    const activeStepIndex = this.mfuStepper?.selectedIndex ?? 0;
 
     this.selectedFolder = undefined;
     this.galerie = undefined;
@@ -949,6 +951,7 @@ export class DetailPmfuComponent {
               }
               await this.setupPmfuForm();
               this.cdr.detectChanges();
+              this.mfuStepper.selectedIndex = activeStepIndex;
               this.isFormValid = true;
               console.log('Projet mis à jour avec succès:', result.formValue);
             },


### PR DESCRIPTION
L'explorateur de fichier du formulaire des projets MFU est de nouveau fonctionnel. Synchronisé sur avec le backend sur la politique de gestion des fichier ( normalisation des noms ).
Ajout, consultation et suppression des elements ok : base de données + systeme de fichiers.