### PR TITLE
feat(gestion): ajouter la gestion des documents planificateurs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dist
 
 .DS_Store
 *.orig
+src/app/sites/site-detail/detail-gestion/assets/

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -48,6 +48,13 @@ export const routes: Routes = [
 
   // Lazy-load
   {
+    path: 'docplan',
+    loadChildren: () =>
+      import('./sites/docplan/docplan.routes').then((mod) => mod.TRAVAUX_ROUTES),
+  },
+
+  // Lazy-load
+  {
     path: 'parametres',
     loadChildren: () =>
       import('./admin/admin.routes').then((mod) => mod.ADMIN_ROUTES),

--- a/src/app/shared/form-buttons/form-buttons.component.scss
+++ b/src/app/shared/form-buttons/form-buttons.component.scss
@@ -28,6 +28,16 @@
       @include icon($couleur-flore, white);
     }
 
+    // Theme connaitre
+    .btn-edition-connaitre {
+      @include btn-icon($bleuM, $bleuC);
+      @include icon(white, black);
+    }
+    .btn-sauvegarde-connaitre {
+      @include btn-icon(white, $bleuM);
+      @include icon($bleuF, white);
+    }
+
     // Theme preferences
     .btn-edition-preferences {
       @include btn-icon($parametres, $bleuC);

--- a/src/app/shared/services/form.service.ts
+++ b/src/app/shared/services/form.service.ts
@@ -26,6 +26,7 @@ import {
 import { Objectif } from '../../sites/site-detail/detail-projets/projet/objectif/objectifs';
 import { ProjetMfu } from '../../sites/foncier/foncier';
 import { SelectValue } from '../interfaces/formValues';
+import { DocPlanDetail } from '../../sites/site-detail/detail-gestion/docplan';
 
 import { MatSnackBar } from '@angular/material/snack-bar';
 
@@ -501,6 +502,37 @@ export class FormService {
       clearError();
       return null;
     };
+  }
+
+  // ============================================================
+  // SECTION DOCPLAN — Documents planificateurs
+  // ============================================================
+
+  newDocPlanForm(doc?: DocPlanDetail, uuid_site?: string): FormGroup {
+    return this.fb.group({
+      uuid_doc: [doc?.uuid_doc || uuidv4()],
+      site: [uuid_site || doc?.site || null],
+      entite_coherente: [doc?.entite_coherente || null],
+      nom: [doc?.nom || '', Validators.required],
+      annee_deb: [doc?.annee_deb || null, [Validators.required, this.integerValidator()]],
+      annee_fin: [doc?.annee_fin || null, [this.integerValidator()]],
+      typ_document: [doc?.typ_document || null, Validators.required],
+      surface: [doc?.surface || null],
+      evaluation: [doc?.evaluation || null, [this.integerValidator()]],
+      actuel: [doc?.actuel || null, Validators.required],
+      url: [doc?.url || null],
+      validite: [doc?.validite !== undefined ? doc.validite : true],
+    });
+  }
+
+  newUniteGestionForm(uuid_doc: string): FormGroup {
+    return this.fb.group({
+      uuid_ug: [uuidv4()],
+      code: [''],
+      nom: [''],
+      surface: [null],
+      document: [uuid_doc],
+    });
   }
 
   newShapeForm(uuid_ope: string, type_geometry: string): FormGroup {

--- a/src/app/sites/docplan/docplan-display/docplan-display.component.html
+++ b/src/app/sites/docplan/docplan-display/docplan-display.component.html
@@ -1,0 +1,104 @@
+<div class="docplan-display">
+  <p>Liste des documents de plans de gestion sélectionnés :</p>
+
+  <p *ngIf="isLoading" class="status-msg">Chargement en cours…</p>
+  <p *ngIf="loadError" class="status-msg error">{{ loadError }}</p>
+
+  <ng-container *ngIf="dataSource">
+    <mat-form-field class="filtre">
+      <mat-label>Mots-clés</mat-label>
+      <input
+        matInput
+        (keyup)="applyFilter($event)"
+        placeholder="Document, site..."
+        #input
+      />
+    </mat-form-field>
+
+    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
+
+      <ng-container matColumnDef="document">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="document">
+          Document
+        </th>
+        <td mat-cell *matCellDef="let element" class="document">
+          {{ element.document }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="code_site">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="code_site">
+          Code site
+        </th>
+        <td mat-cell *matCellDef="let element" class="code_site">
+          {{ element.code_site }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="annee_deb">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="annee_deb">
+          Année début
+        </th>
+        <td mat-cell *matCellDef="let element" class="annee_deb">
+          {{ element.annee_deb }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="annee_fin">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="annee_fin">
+          Année fin
+        </th>
+        <td mat-cell *matCellDef="let element" class="annee_fin">
+          {{ element.annee_fin }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="docactuel">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="docactuel">
+          Actuel
+        </th>
+        <td mat-cell *matCellDef="let element" class="docactuel">
+          {{ element.docactuel }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="typ_document">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="typ_document">
+          Type
+        </th>
+        <td mat-cell *matCellDef="let element" class="typ_document">
+          {{ element.typ_document }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="surface">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="surface">
+          Surface (ha)
+        </th>
+        <td mat-cell *matCellDef="let element" class="surface">
+          {{ element.surface }}
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"
+          (click)="onSelect(row)"
+          class="clickable-row"></tr>
+
+      <tr class="mat-row" *matNoDataRow>
+        <td class="mat-cell" colspan="7">
+          Pas de donnée correspondante à votre filtre sur le mot clé :
+          "{{ input.value }}"
+        </td>
+      </tr>
+    </table>
+
+    <mat-paginator
+      [pageSize]="20"
+      [pageSizeOptions]="[5, 10, 20]"
+      showFirstLastButtons
+      aria-label="Tableau de sélection des documents de plans de gestion."
+    >
+    </mat-paginator>
+  </ng-container>
+</div>

--- a/src/app/sites/docplan/docplan-display/docplan-display.component.scss
+++ b/src/app/sites/docplan/docplan-display/docplan-display.component.scss
@@ -1,0 +1,28 @@
+@import "../../../styles/variables.scss";
+
+.status-msg {
+  padding: 8px 0;
+  &.error { color: $superRed; }
+}
+
+.docplan-display {
+  width: 100%;
+}
+
+.clickable-row {
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.04);
+  }
+}
+
+@media screen and (max-width: $mobile) {
+  .docplan-display {
+    .code_site,
+    .annee_fin,
+    .surface {
+      display: none;
+    }
+  }
+}

--- a/src/app/sites/docplan/docplan-display/docplan-display.component.ts
+++ b/src/app/sites/docplan/docplan-display/docplan-display.component.ts
@@ -1,0 +1,143 @@
+import { Component, inject, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Params } from '@angular/router';
+
+import { MatPaginator, MatPaginatorModule, MatPaginatorIntl } from '@angular/material/paginator';
+import { CustomMatPaginatorIntl } from '../../../shared/costomMaterial/custom-matpaginator-intl';
+
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { Overlay } from '@angular/cdk/overlay';
+
+import { DocPlanListe } from '../docplan';
+import { DocplanService } from '../docplan.service';
+import { DocPlanFicheComponent } from '../../site-detail/detail-gestion/docplan-fiche/docplan-fiche.component';
+
+@Component({
+  selector: 'app-docplan-display',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSortModule,
+    MatPaginatorModule,
+    MatDialogModule,
+  ],
+  templateUrl: './docplan-display.component.html',
+  styleUrl: './docplan-display.component.scss',
+  providers: [{ provide: MatPaginatorIntl, useClass: CustomMatPaginatorIntl }],
+})
+export class DocplanDisplayComponent {
+  public docplans: DocPlanListe[] = [];
+  selectedDocplan?: DocPlanListe;
+  public isLoading: boolean = false;
+  public loadError: string | null = null;
+
+  public dataSource!: MatTableDataSource<DocPlanListe>;
+  public displayedColumns: string[] = [
+    'document',
+    'code_site',
+    'annee_deb',
+    'annee_fin',
+    'docactuel',
+    'typ_document',
+    'surface',
+  ];
+
+  private _paginator!: MatPaginator;
+  private _sort!: MatSort;
+
+  @ViewChild(MatPaginator) set paginator(p: MatPaginator) {
+    this._paginator = p;
+    if (this.dataSource) this.dataSource.paginator = p;
+  }
+
+  @ViewChild(MatSort) set sort(s: MatSort) {
+    this._sort = s;
+    if (this.dataSource) this.dataSource.sort = s;
+  }
+
+  private research: DocplanService = inject(DocplanService);
+  private route: ActivatedRoute = inject(ActivatedRoute);
+  private dialog: MatDialog = inject(MatDialog);
+  private overlay: Overlay = inject(Overlay);
+
+  private loadDocplans(params: Params): void {
+    const subroute =
+      'pgestion/criteria/' +
+      params['annee_deb'] +
+      '/' +
+      params['localisation'] +
+      '/' +
+      params['typ_document'] +
+      '/' +
+      params['actuel'];
+
+    this.isLoading = true;
+    this.loadError = null;
+
+    this.research.getDocplans(subroute)
+      .then((docplansGuetted: DocPlanListe[]) => {
+        this.docplans = docplansGuetted;
+        this.dataSource = new MatTableDataSource(this.docplans);
+        this.dataSource.paginator = this._paginator;
+        this.dataSource.sort = this._sort;
+      })
+      .catch((err) => {
+        console.error('Erreur chargement pgestion/criteria', err);
+        this.loadError = `Impossible de charger les documents (${subroute})`;
+      })
+      .finally(() => {
+        this.isLoading = false;
+      });
+  }
+
+  ngOnInit() {
+    this.route.params.subscribe((params: Params) => {
+      this.loadDocplans(params);
+    });
+  }
+
+  applyFilter(event: Event) {
+    if (!this.dataSource) return;
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
+  }
+
+  onSelect(docplan: DocPlanListe): void {
+    if (docplan.uuid_doc) {
+      this.openDialog(docplan);
+    } else {
+      console.log('Pas de uuid_doc pour ouvrir le document : ', docplan);
+    }
+  }
+
+  openDialog(docplan: DocPlanListe): void {
+    const dialogRef = this.dialog.open(DocPlanFicheComponent, {
+      data: { uuid_doc: docplan.uuid_doc, uuid_site: '' },
+      minWidth: '50vw',
+      maxWidth: '95vw',
+      height: '70vh',
+      maxHeight: '90vh',
+      hasBackdrop: true,
+      backdropClass: 'custom-backdrop-gerer',
+      enterAnimationDuration: '400ms',
+      exitAnimationDuration: '300ms',
+      scrollStrategy: this.overlay.scrollStrategies.close(),
+    });
+
+    dialogRef.afterClosed().subscribe(() => {
+      this.route.params.subscribe((params: Params) => {
+        this.loadDocplans(params);
+      });
+    });
+  }
+}

--- a/src/app/sites/docplan/docplan-research/docplan-research.component.html
+++ b/src/app/sites/docplan/docplan-research/docplan-research.component.html
@@ -1,0 +1,37 @@
+<div class="conteneur">
+  <p *ngIf="selectorsError" class="selectors-error">
+    Les filtres sont indisponibles (endpoint <code>pgestion/selectors</code> manquant côté backend).
+  </p>
+  <div class="recherche">
+    <mat-form-field
+      *ngFor="let selector of selectors"
+      appearance="fill"
+      [ngClass]="[
+        'selecteur',
+        selector.name === 'localisation' ? 'selecteur-localisation' : ''
+      ]"
+    >
+      <mat-label ngClass="label">{{ selector.title }} :</mat-label>
+      <mat-select
+        id="{{ selector.name }}"
+        (selectionChange)="selectionSelectors($event, selector.name)"
+      >
+        <mat-option [value]="{ id: selector.name, name: selector.name }" selected>
+          Selectionner {{ selector.name }}
+        </mat-option>
+        <mat-option
+          *ngFor="let value of selector.values"
+          [value]="{ id: value, name: value }"
+        >
+          {{ value }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <div class="btn">
+    <button mat-button-flat (click)="docplanSelection()">
+      Sélection des documents
+    </button>
+  </div>
+</div>

--- a/src/app/sites/docplan/docplan-research/docplan-research.component.scss
+++ b/src/app/sites/docplan/docplan-research/docplan-research.component.scss
@@ -1,0 +1,81 @@
+@import "../../../styles/variables.scss";
+@import "../../../styles/mixins.scss";
+
+.selectors-error {
+  color: $superRed;
+  font-size: $p12;
+  margin-bottom: 8px;
+}
+
+.conteneur {
+  @include dim(100%, auto);
+  display: grid;
+  grid-template-rows: 2fr 1fr;
+  flex-wrap: wrap;
+  padding-bottom: 20px;
+  margin-bottom: 20px;
+  .recherche {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    flex-wrap: wrap;
+    gap: 31px;
+    padding-top: 20px;
+    @include dim(auto, auto);
+    @include align(center, space-between);
+  }
+  .selecteur {
+    @include dim(100%, auto);
+  }
+  .selecteur-localisation {
+    grid-column: span 2;
+  }
+  .label {
+    @include Typo($p14, $normal, $couleur-flore);
+  }
+  .btn {
+    display: flex;
+    @include align(center, center);
+    margin: 0 40px 0 19px;
+    button {
+      @include btn($couleur-flore, white, white, $couleur-territoire);
+      @include align(center, center);
+    }
+  }
+}
+
+@media screen and (max-width: $mobile) {
+  .conteneur {
+    grid-template-rows: 1fr 30%;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+    .recherche {
+      grid-template-columns: 1fr 1fr;
+    }
+    .label {
+      font-size: $p12;
+    }
+
+    .btn {
+      padding: 20px;
+      height: 30%;
+    }
+  }
+}
+
+@media screen and (min-width: $mobile) and (max-width: $tablette) {
+  .conteneur {
+    grid-template-rows: 1fr 30%;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+    .recherche {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
+    .label {
+      font-size: $p12;
+    }
+
+    .btn {
+      height: 30%;
+    }
+  }
+}

--- a/src/app/sites/docplan/docplan-research/docplan-research.component.ts
+++ b/src/app/sites/docplan/docplan-research/docplan-research.component.ts
@@ -1,0 +1,84 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+
+import { Selector } from '../../../shared/interfaces/selector';
+import { DocplanService } from '../docplan.service';
+
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+
+@Component({
+  selector: 'app-docplan-research',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatSelectModule,
+  ],
+  templateUrl: './docplan-research.component.html',
+  styleUrl: './docplan-research.component.scss',
+})
+export class DocplanResearchComponent implements OnInit {
+  private params: Record<string, string> = {
+    annee_deb: '*',
+    localisation: '*',
+    typ_document: '*',
+    actuel: '*',
+  };
+
+  public selectors: Selector[] = [];
+  private research: DocplanService = inject(DocplanService);
+
+  public selectorsError: boolean = false;
+
+  constructor(private router: Router) {
+    this.research.getSelectors()
+      .then((selectors: Selector[]) => {
+        const order = ['localisation', 'annee_deb', 'typ_document', 'actuel'];
+        this.selectors = selectors.slice().sort((a, b) => {
+          const aIndex = order.indexOf(a.name);
+          const bIndex = order.indexOf(b.name);
+          const safeA = aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex;
+          const safeB = bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex;
+          return safeA - safeB;
+        });
+      })
+      .catch((err) => {
+        console.error('Impossible de charger les sélecteurs docplan (pgestion/selectors)', err);
+        this.selectorsError = true;
+      });
+  }
+
+  ngOnInit() {}
+
+  selectionSelectors($event: any, selector: string) {
+    const optionText = $event.value.name;
+
+    if (selector === optionText) {
+      this.params[selector] = '*';
+    } else {
+      this.params[selector] = optionText;
+    }
+  }
+
+  docplanSelection() {
+    this.router.navigate([
+      '/docplan',
+      {
+        outlets: {
+          liste: [
+            'filtre',
+            this.params['annee_deb'],
+            this.params['localisation'].split(' - ')[0],
+            this.params['typ_document'],
+            this.params['actuel'],
+          ],
+        },
+      },
+    ]);
+  }
+}

--- a/src/app/sites/docplan/docplan.component.html
+++ b/src/app/sites/docplan/docplan.component.html
@@ -1,0 +1,8 @@
+<div class="site-parent">
+  <div class="proteger">Documents de plans de gestion</div>
+
+  <div class="sites-enfants">
+    <app-docplan-research></app-docplan-research>
+    <router-outlet name="liste"></router-outlet>
+  </div>
+</div>

--- a/src/app/sites/docplan/docplan.component.scss
+++ b/src/app/sites/docplan/docplan.component.scss
@@ -1,0 +1,34 @@
+@import "../../styles/variables.scss";
+@import "../../styles/mixins.scss";
+
+.site-parent {
+	display: flex;
+	flex-direction: row;
+	width: 100%;
+	height: 100%;
+	min-height: 100vh;
+}
+
+.proteger {
+	padding-bottom: 15px;
+	@include bandeau($couleur-flore);
+}
+
+.sites-enfants {
+	width: 100%;
+	margin: 0 50px 25px 29px;
+}
+
+@media screen and (max-width: $mobile) {
+	.sites-enfants {
+		width: 100%;
+		margin: 0 25px 25px 5px;
+	}
+}
+
+@media screen and (max-width: $tablette) {
+	.sites-enfants {
+		width: 100%;
+		margin: 0 25px 25px 5px;
+	}
+}

--- a/src/app/sites/docplan/docplan.component.ts
+++ b/src/app/sites/docplan/docplan.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { RouterLink, RouterOutlet } from '@angular/router';
+
+import { DocplanResearchComponent } from './docplan-research/docplan-research.component';
+import { DocplanDisplayComponent } from './docplan-display/docplan-display.component';
+import { BackToTopComponent } from '../../back-to-top/back-to-top.component';
+
+@Component({
+  selector: 'app-docplan',
+  standalone: true,
+  imports: [
+    RouterLink,
+    RouterOutlet,
+    DocplanResearchComponent,
+    DocplanDisplayComponent,
+    BackToTopComponent,
+  ],
+  templateUrl: './docplan.component.html',
+  styleUrl: './docplan.component.scss',
+})
+export class DocplanComponent {}

--- a/src/app/sites/docplan/docplan.routes.ts
+++ b/src/app/sites/docplan/docplan.routes.ts
@@ -1,0 +1,19 @@
+import { Route } from '@angular/router';
+import { DocplanComponent } from './docplan.component';
+import { DocplanDisplayComponent } from './docplan-display/docplan-display.component';
+
+export const TRAVAUX_ROUTES: Route[] = [
+  {
+    path: '',
+    component: DocplanComponent,
+    pathMatch: 'prefix',
+    providers: [],
+    children: [
+      {
+        path: 'filtre/:annee_deb/:localisation/:typ_document/:actuel',
+        component: DocplanDisplayComponent,
+        outlet: 'liste',
+      },
+    ],
+  },
+];

--- a/src/app/sites/docplan/docplan.service.ts
+++ b/src/app/sites/docplan/docplan.service.ts
@@ -1,0 +1,36 @@
+import { environment } from '../../../environments/environment';
+
+import { Injectable } from '@angular/core';
+
+import { DocPlanListe } from './docplan';
+import { Selector } from '../../shared/interfaces/selector';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DocplanService {
+  private activeUrl: string = environment.apiUrl + 'sites/';
+
+  async getData<T>(subroute: string): Promise<T> {
+    const url = `${this.activeUrl}${subroute}`;
+    console.log(`DocplanService → fetch : ${url}`);
+
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`HTTP ${response.status} sur ${url} — ${body}`);
+    }
+
+    return (await response.json()) ?? [];
+  }
+
+  async getSelectors(): Promise<Selector[]> {
+    return this.getData<Selector[]>('selectors_pgestion');
+  }
+
+  async getDocplans(subroute: string): Promise<DocPlanListe[]> {
+    console.log(`Dans getDocplans() avec ${subroute}`);
+    return this.getData<DocPlanListe[]>(subroute);
+  }
+}

--- a/src/app/sites/docplan/docplan.ts
+++ b/src/app/sites/docplan/docplan.ts
@@ -1,0 +1,10 @@
+export interface DocPlanListe {
+  uuid_doc: string;
+  document: string;
+  code_site: string;
+  annee_deb: number;
+  annee_fin: number | null;
+  docactuel: string;
+  typ_document: string | null;
+  surface: number | null;
+}

--- a/src/app/sites/site-detail/detail-gestion/detail-gestion.component.html
+++ b/src/app/sites/site-detail/detail-gestion/detail-gestion.component.html
@@ -1,64 +1,113 @@
-<div *ngIf="docPlan.length > 0; then thenBlock else elseBlock"></div>
+<div class="edition">
+  Ajouter un document planificateur :
+  <button mat-icon-button
+          matTooltip="Ajouter un document planificateur"
+          class="btn-edition"
+          (click)="openDialog()">
+    <mat-icon>add</mat-icon>
+  </button>
+</div>
 
-<ng-template #thenBlock>
-    Nb de plans de gestion : {{ docPlan.length }}<br>
-    <ul>
-        <li *ngFor="let doc of docPlan">
-          Document : {{ doc.document }}<br>
-          Année début : {{ doc.annee_deb }}<br>
-          Année fin : {{ doc.annee_fin }}<br>
-          Surface : {{ doc.surface }}<br>
-          Doc. actuel : {{ doc.docactuel }}<br>
-          Lien du document : <a [href]="doc.url" target="_blank">Télécharger</a>
-        </li>
-      </ul>
-</ng-template>
+<div *ngIf="docPlan.length > 0; then thenBlock; else elseBlock"></div>
 
-<ng-template #elseBlock>
-    Il n'y a pas de plan de gestion sur ce site.
-</ng-template>
+<div class="detail-gestion">
+
+  <ng-template #thenBlock>
+    <h2>Documents planificateurs : {{ docPlan.length }}</h2>
+
+    <mat-form-field class="filter-field">
+      <mat-label>Rechercher</mat-label>
+      <input matInput (keyup)="applyFilter($event)" placeholder="Filtrer les documents...">
+      <mat-icon matSuffix>search</mat-icon>
+    </mat-form-field>
+
+    <mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
+
+      <ng-container matColumnDef="document">
+        <mat-header-cell *matHeaderCellDef mat-sort-header>Nom du document</mat-header-cell>
+        <mat-cell *matCellDef="let element; let i = index"
+                  [ngClass]="{'even-row': i % 2 === 0, 'odd-row': i % 2 !== 0}">
+          {{ element.document }}
+        </mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="annee_deb">
+        <mat-header-cell *matHeaderCellDef mat-sort-header class="col-annee">Début</mat-header-cell>
+        <mat-cell *matCellDef="let element; let i = index" class="col-annee"
+                  [ngClass]="{'even-row': i % 2 === 0, 'odd-row': i % 2 !== 0}">
+          {{ element.annee_deb }}
+        </mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="annee_fin">
+        <mat-header-cell *matHeaderCellDef mat-sort-header class="col-annee">Fin</mat-header-cell>
+        <mat-cell *matCellDef="let element; let i = index" class="col-annee"
+                  [ngClass]="{'even-row': i % 2 === 0, 'odd-row': i % 2 !== 0}">
+          {{ element.annee_fin || '—' }}
+        </mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="actuel">
+        <mat-header-cell *matHeaderCellDef mat-sort-header class="col-actuel">En cours</mat-header-cell>
+        <mat-cell *matCellDef="let element; let i = index" class="col-actuel"
+                  [ngClass]="{'even-row': i % 2 === 0, 'odd-row': i % 2 !== 0}">
+          {{ element.docactuel }}
+        </mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="pdf">
+        <mat-header-cell *matHeaderCellDef class="col-pdf">PDF</mat-header-cell>
+        <mat-cell *matCellDef="let element; let i = index" class="col-pdf"
+                  [ngClass]="{'even-row': i % 2 === 0, 'odd-row': i % 2 !== 0}">
+          <a *ngIf="element.url" [href]="element.url" target="_blank"
+             matTooltip="Ouvrir le PDF" (click)="$event.stopPropagation()">
+            <mat-icon class="pdf-icon">picture_as_pdf</mat-icon>
+          </a>
+          <span *ngIf="!element.url">—</span>
+        </mat-cell>
+      </ng-container>
+
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns"
+               (click)="openDialog(row)"></mat-row>
+    </mat-table>
+  </ng-template>
+
+  <ng-template #elseBlock>
+    Il n'y a pas de document planificateur associé à ce site.
+  </ng-template>
+
+</div>
 
 <div *ngIf="inputDetail !== undefined">
-    <table>
-        <tbody>
-            <tr>
-                <td colspan="2">
-                    Agriculteurs/trices sous contrat ou convention : 
-                </td>
-            </tr>
-            <tr>
-                <td colspan="2">
-                    <section>---Tableau à venir---</section>
-                </td>
-            </tr>
+  <table>
+    <tbody>
+      <tr>
+        <td colspan="2">Agriculteurs/trices sous contrat ou convention :</td>
+      </tr>
+      <tr>
+        <td colspan="2"><section>---Tableau à venir---</section></td>
+      </tr>
 
-            <tr>
-                <td colspan="2">
-                    Surfaces en libre évolution : 
-                </td>
-            </tr>
-            <tr>
-                <td colspan="2">
-                    <section>---Tableau à venir---</section>
-                </td>
-            </tr>
+      <tr>
+        <td colspan="2">Surfaces en libre évolution :</td>
+      </tr>
+      <tr>
+        <td colspan="2"><section>---Tableau à venir---</section></td>
+      </tr>
 
-            <tr>
-                <td colspan="2">
-                    Conservateur/trice(s) bénévoles : 
-                </td>
-            </tr>
-            <tr>
-                <td colspan="2">
-                    <section>---Tableau à venir---</section>
-                </td>
-            </tr>
-            
-            <tr>
-                <td colspan="2">
-                    Pourcentage estimé du site dont la gestion est assurée : {{inputDetail.pourc_gere}}%
-                </td>
-            </tr>
-        </tbody>
-      </table>
+      <tr>
+        <td colspan="2">Conservateur/trice(s) bénévoles :</td>
+      </tr>
+      <tr>
+        <td colspan="2"><section>---Tableau à venir---</section></td>
+      </tr>
+
+      <tr>
+        <td colspan="2">
+          Pourcentage estimé du site dont la gestion est assurée : {{inputDetail.pourc_gere}}%
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>

--- a/src/app/sites/site-detail/detail-gestion/detail-gestion.component.scss
+++ b/src/app/sites/site-detail/detail-gestion/detail-gestion.component.scss
@@ -1,0 +1,91 @@
+@import "../../../styles/mixins.scss";
+@import "../../../styles/variables.scss";
+
+.edition {
+  display: flex;
+  @include align(center, start);
+  margin-bottom: 20px;
+  gap: 15px;
+  .btn-edition {
+    @include btn-icon($proteger, $orangeC);
+    @include icon(white, black);
+  }
+}
+
+.detail-gestion {
+  margin-top: 8px;
+
+  h2 {
+    font-size: 1rem;
+    font-weight: 500;
+    margin-bottom: 8px;
+    color: #333;
+  }
+}
+
+.filter-field {
+  width: 100%;
+  margin-bottom: 12px;
+
+  // Thème orange (couleur-faune) pour le champ de recherche
+  --mdc-filled-text-field-active-indicator-color: #{$couleur-faune};
+  --mdc-filled-text-field-focus-active-indicator-color: #{$couleur-faune};
+  --mdc-filled-text-field-focus-label-text-color: #{$couleur-faune};
+  --mat-form-field-focus-select-arrow-color: #{$couleur-faune};
+  --mat-select-focused-arrow-color: #{$couleur-faune};
+}
+
+mat-table {
+  width: 100%;
+  margin-bottom: 24px;
+}
+
+// Ligne de titre
+.mat-mdc-table mat-header-row.mat-mdc-header-row {
+  border-bottom: 2px solid $couleur-faune;
+}
+
+.col-annee {
+  max-width: 70px;
+  flex: 0 0 70px;
+}
+
+.col-actuel {
+  max-width: 90px;
+  flex: 0 0 90px;
+}
+
+.col-pdf {
+  max-width: 60px;
+  flex: 0 0 60px;
+  justify-content: center;
+}
+
+.pdf-icon {
+  color: #c62828;
+  font-size: 20px;
+}
+
+mat-row {
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.04);
+  }
+}
+
+.even-row {
+  background-color: white;
+}
+
+.odd-row {
+  background-color: #f2f2f2;
+}
+
+// Responsive
+@media screen and (max-width: $mobile) {
+  .col-annee,
+  .col-actuel {
+    display: none;
+  }
+}

--- a/src/app/sites/site-detail/detail-gestion/detail-gestion.component.ts
+++ b/src/app/sites/site-detail/detail-gestion/detail-gestion.component.ts
@@ -1,55 +1,112 @@
-import { Component, Input, inject, SimpleChanges, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, inject, SimpleChanges, ChangeDetectorRef, ViewChild, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { DetailSite } from '../../site-detail';
 import { DocPlan } from './docplan';
-import { SitesService } from '../../sites.service'; // service de données
+import { SitesService } from '../../sites.service';
+import { DocPlanFicheComponent } from './docplan-fiche/docplan-fiche.component';
+
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { Overlay } from '@angular/cdk/overlay';
 
 @Component({
   selector: 'app-detail-gestion',
   standalone: true,
-  imports: [CommonModule,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatDialogModule,
   ],
   templateUrl: './detail-gestion.component.html',
   styleUrls: ['./detail-gestion.component.scss']
 })
-export class DetailGestionComponent {
-  @Input() inputDetail?: DetailSite; // Le site selectionné pour voir son détail vient du composant parent
-  @Input() inputUUIDsite?: String; // L'uuid du site selectionné
+export class DetailGestionComponent implements AfterViewInit {
+  @Input() inputDetail?: DetailSite;
+  @Input() inputUUIDsite?: String;
+
+  @ViewChild(MatSort) sort!: MatSort;
+
   public docPlan: DocPlan[] = [];
+  public dataSource!: MatTableDataSource<DocPlan>;
+  public displayedColumns: string[] = ['document', 'annee_deb', 'annee_fin', 'actuel', 'pdf'];
 
   research: SitesService = inject(SitesService);
   private cdr: ChangeDetectorRef = inject(ChangeDetectorRef);
 
+  constructor(
+    private dialog: MatDialog,
+    private overlay: Overlay
+  ) {}
+
+  ngAfterViewInit(): void {
+    if (this.dataSource) {
+      this.dataSource.sort = this.sort;
+    }
+  }
+
+  get uuid_site(): string | undefined {
+    return (this.inputDetail?.uuid_site || this.inputUUIDsite) as string | undefined;
+  }
+
   async ngOnChanges(changes: SimpleChanges) {
     if (this.inputDetail !== undefined) {
-      const subroute = `pgestion/uuid=${this.inputDetail.uuid_site}`;
-      // console.log("subroute pour les plans de gestion : " + subroute);
-      console.log("Ouais on est dans le OnChanges 'onglet GESTION' . UUID:" + this.inputDetail["uuid_site"]);
-      await this.fetchDocPlan(subroute);
+      console.log("Onglet GESTION — ngOnChanges. UUID site :", this.inputDetail.uuid_site);
+      await this.fetchDocPlan(`pgestion/uuid=${this.inputDetail.uuid_site}`);
     }
   }
 
   async ngOnInit() {
     if (this.inputUUIDsite !== undefined) {
-      const subroute = `pgestion/uuid=${this.inputUUIDsite}`;
-      console.log("subroute pour les plans de gestion dans ngOnInit : " + subroute);
-      await this.fetchDocPlan(subroute);
+      await this.fetchDocPlan(`pgestion/uuid=${this.inputUUIDsite}`);
     }
   }
 
   private async fetchDocPlan(subroute: string) {
     try {
       this.docPlan = await this.research.getDocPlan(subroute);
-      console.log('docPlan après assignation :', this.docPlan);
-      this.cdr.detectChanges(); // Forcer la détection des changements
+      this.dataSource = new MatTableDataSource(this.docPlan);
+      this.dataSource.sort = this.sort;
+      this.cdr.detectChanges();
     } catch (error) {
-      console.error('Error fetching documents', error);
+      console.error('Erreur lors du chargement des documents planificateurs', error);
     }
   }
 
+  applyFilter(event: Event): void {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+  }
 
+  openDialog(doc?: DocPlan): void {
+    const uuid_site = this.uuid_site;
+    if (!uuid_site) return;
 
+    const dialogRef = this.dialog.open(DocPlanFicheComponent, {
+      data: { uuid_doc: doc?.uuid_doc, uuid_site },
+      minWidth: '50vw',
+      maxWidth: '95vw',
+      height: '80vh',
+      maxHeight: '90vh',
+      hasBackdrop: true,
+      backdropClass: 'custom-backdrop-gerer',
+      enterAnimationDuration: '400ms',
+      exitAnimationDuration: '300ms',
+      scrollStrategy: this.overlay.scrollStrategies.close(),
+    });
 
-
+    dialogRef.afterClosed().subscribe(() => {
+      this.ngOnChanges({});
+    });
+  }
 }

--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.html
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.html
@@ -1,0 +1,253 @@
+<mat-dialog-content class="dialogue" *ngIf="!isLoading; else loading">
+<div class="conteneur-docplan">
+  <div class="connaitre">Connaître</div>
+  <div class="docplan">
+
+  <!-- En-tête : boutons + titre -->
+  <div class="button-title">
+    <div class="form-buttons">
+      <app-form-buttons
+        [isEditActive]="isEditMode"
+        icone="edit"
+        [theme]="'connaitre'"
+        [isFormValid]="isFormValid"
+        (toggleAction)="toggleEdit()"
+        (onSubmit)="onSubmit()"
+      ></app-form-buttons>
+    </div>
+
+    <div class="title-container">
+      <h2 *ngIf="isNewDoc">Nouveau document planificateur</h2>
+      <h2 *ngIf="!isNewDoc && !isEditMode">Document planificateur</h2>
+      <h2 *ngIf="!isNewDoc && isEditMode">Modification du document planificateur</h2>
+    </div>
+  </div>
+
+  <!-- ==============================
+       MODE CONSULTATION
+  =============================== -->
+  <ng-container *ngIf="!isEditMode">
+
+    <mat-form-field class="custom-mat-form-field full-width">
+      <mat-label>Nom du document</mat-label>
+      <input matInput [value]="docPlanForm.get('nom')?.value || 'Non renseigné'" readonly>
+    </mat-form-field>
+
+    <div class="form-row">
+      <mat-form-field class="custom-mat-form-field">
+        <mat-label>Année début</mat-label>
+        <input matInput [value]="docPlanForm.get('annee_deb')?.value || 'Non renseigné'" readonly>
+      </mat-form-field>
+
+      <mat-form-field class="custom-mat-form-field">
+        <mat-label>Année fin</mat-label>
+        <input matInput [value]="docPlanForm.get('annee_fin')?.value || '—'" readonly>
+      </mat-form-field>
+
+      <mat-form-field class="custom-mat-form-field">
+        <mat-label>Type de document</mat-label>
+        <input matInput [value]="getTypDocLibelle(docPlanForm.get('typ_document')?.value)" readonly>
+      </mat-form-field>
+    </div>
+
+    <div class="form-row">
+      <mat-form-field class="custom-mat-form-field">
+        <mat-label>Surface du site concerné (ha)</mat-label>
+        <input matInput [value]="docPlanForm.get('surface')?.value ?? '—'" readonly>
+      </mat-form-field>
+
+      <mat-form-field class="custom-mat-form-field">
+        <mat-label>Année d'évaluation</mat-label>
+        <input matInput [value]="docPlanForm.get('evaluation')?.value ?? '—'" readonly>
+      </mat-form-field>
+
+      <mat-form-field class="custom-mat-form-field">
+        <mat-label>Document en cours de validité ?</mat-label>
+        <input matInput [value]="docPlanForm.get('actuel')?.value || 'Non renseigné'" readonly>
+      </mat-form-field>
+    </div>
+
+    <div class="download-cell" *ngIf="docPlanForm.get('url')?.value">
+      📎 <a [href]="docPlanForm.get('url')?.value" target="_blank">Télécharger le document planificateur</a>
+    </div>
+    <div class="download-cell no-pdf" *ngIf="!isNewDoc && !docPlanForm.get('url')?.value">
+      Aucun document PDF disponible
+    </div>
+
+  </ng-container>
+
+  <!-- ==============================
+       MODE ÉDITION
+  =============================== -->
+  <ng-container *ngIf="isEditMode">
+    <form [formGroup]="docPlanForm">
+
+      <mat-form-field class="full-width">
+        <mat-label>Nom du document *</mat-label>
+        <textarea matInput formControlName="nom" rows="2"></textarea>
+        <mat-error *ngIf="docPlanForm.get('nom')?.hasError('required')">Champ obligatoire</mat-error>
+      </mat-form-field>
+
+      <div class="form-row">
+        <mat-form-field>
+          <mat-label>Année début *</mat-label>
+          <input matInput type="number" formControlName="annee_deb">
+          <mat-error *ngIf="docPlanForm.get('annee_deb')?.hasError('required')">Champ obligatoire</mat-error>
+          <mat-error *ngIf="docPlanForm.get('annee_deb')?.hasError('integer')">Doit être un entier</mat-error>
+        </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Année fin</mat-label>
+          <input matInput type="number" formControlName="annee_fin">
+          <mat-error *ngIf="docPlanForm.get('annee_fin')?.hasError('integer')">Doit être un entier</mat-error>
+        </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Type de document *</mat-label>
+          <mat-select formControlName="typ_document">
+            <mat-option *ngFor="let t of typesDocument" [value]="t.cd_type">{{ t.libelle }}</mat-option>
+          </mat-select>
+          <mat-error *ngIf="docPlanForm.get('typ_document')?.hasError('required')">Champ obligatoire</mat-error>
+        </mat-form-field>
+      </div>
+
+      <div class="form-row">
+        <mat-form-field>
+          <mat-label>Surface du site concerné (ha)</mat-label>
+          <input matInput type="number" step="0.0001" formControlName="surface">
+        </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Année d'évaluation</mat-label>
+          <input matInput type="number" formControlName="evaluation">
+          <mat-error *ngIf="docPlanForm.get('evaluation')?.hasError('integer')">Doit être un entier</mat-error>
+        </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Document en cours de validité ? *</mat-label>
+          <mat-select formControlName="actuel">
+            <mat-option *ngFor="let o of actuelOptions" [value]="o.cd_type">{{ o.libelle }}</mat-option>
+          </mat-select>
+          <mat-error *ngIf="docPlanForm.get('actuel')?.hasError('required')">Champ obligatoire</mat-error>
+        </mat-form-field>
+      </div>
+
+      <mat-form-field class="full-width" *ngIf="isAdmin">
+        <mat-label>URL du PDF</mat-label>
+        <input matInput formControlName="url" placeholder="https://...">
+      </mat-form-field>
+
+      <div class="download-cell" *ngIf="!isNewDoc && docPlanForm.get('url')?.value">
+        📎 <a [href]="docPlanForm.get('url')?.value" target="_blank">Télécharger le document planificateur</a>
+      </div>
+      <div class="download-cell no-pdf" *ngIf="!isNewDoc && !docPlanForm.get('url')?.value">
+        Aucun document PDF disponible
+      </div>
+
+    </form>
+  </ng-container>
+
+  <!-- Note informative -->
+  <p class="note-info">
+    Un document planificateur peut être associé à un ou plusieurs sites. S'il concerne plusieurs sites,
+    on considère que ces sites constituent une entité cohérente de gestion (qu'ils soient nommés ainsi
+    sur le document ou non). Il ne faut donc pas créer plusieurs fois le même document, mais indiquer
+    dans le champ ci-dessous l'entité cohérente de gestion correspondante, après l'avoir créée.
+  </p>
+
+  <!-- ==============================
+       UNITÉS DE GESTION
+  =============================== -->
+  <div class="ug-section">
+
+    <div class="ug-header">
+      <h3>Unités de gestion</h3>
+      <button mat-icon-button type="button"
+              matTooltip="Ajouter une unité de gestion"
+              *ngIf="isEditMode && !isAddingUG"
+              (click)="startAddUG()">
+        <mat-icon>add</mat-icon>
+      </button>
+    </div>
+
+    <mat-table [dataSource]="ugDataSource" class="mat-elevation-z2"
+               *ngIf="unitesGestion.length > 0 || isAddingUG">
+
+      <ng-container matColumnDef="code">
+        <mat-header-cell *matHeaderCellDef>Code UG</mat-header-cell>
+        <mat-cell *matCellDef="let ug">{{ ug.code }}</mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="nom">
+        <mat-header-cell *matHeaderCellDef>Nom</mat-header-cell>
+        <mat-cell *matCellDef="let ug">{{ ug.nom }}</mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="surface">
+        <mat-header-cell *matHeaderCellDef>Surface (ha)</mat-header-cell>
+        <mat-cell *matCellDef="let ug">{{ ug.surface }}</mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let ug">
+          <button mat-icon-button color="warn"
+                  *ngIf="isEditMode"
+                  matTooltip="Supprimer cette unité de gestion"
+                  (click)="deleteUG(ug)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </mat-cell>
+      </ng-container>
+
+      <mat-header-row *matHeaderRowDef="ugColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: ugColumns"></mat-row>
+    </mat-table>
+
+    <p class="no-ug" *ngIf="unitesGestion.length === 0 && !isAddingUG">
+      Aucune unité de gestion enregistrée.
+    </p>
+
+    <!-- Formulaire d'ajout d'une UG -->
+    <div *ngIf="isAddingUG" class="ug-add-form" [formGroup]="ugForm">
+      <mat-form-field class="ug-field">
+        <mat-label>Code UG</mat-label>
+        <input matInput formControlName="code">
+      </mat-form-field>
+
+      <mat-form-field class="ug-field">
+        <mat-label>Nom</mat-label>
+        <input matInput formControlName="nom">
+      </mat-form-field>
+
+      <mat-form-field class="ug-field-surface">
+        <mat-label>Surface (ha)</mat-label>
+        <input matInput type="number" step="0.0001" formControlName="surface">
+      </mat-form-field>
+
+      <button mat-icon-button color="primary" type="button"
+              matTooltip="Valider l'ajout"
+              (click)="saveUG()">
+        <mat-icon>check</mat-icon>
+      </button>
+
+      <button mat-icon-button type="button"
+              matTooltip="Annuler"
+              (click)="cancelAddUG()">
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
+
+  </div>
+
+  </div>
+</div>
+</mat-dialog-content>
+
+<!-- Spinner de chargement -->
+<ng-template #loading>
+  <div class="loading-container">
+    <mat-spinner class="spinner-vert"></mat-spinner>
+    <p>Chargement...</p>
+  </div>
+</ng-template>

--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.scss
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.scss
@@ -1,0 +1,198 @@
+@use '@angular/material' as mat;
+@import "../../../../styles/themes.scss";
+@import "../../../../styles/mixins.scss";
+@import "../../../../styles/variables.scss";
+
+:host {
+  @include mat.all-component-themes(mat.m2-define-light-theme((
+    color: (
+      primary: $connaitre-palette,
+      accent:  mat.m2-define-palette(mat.$m2-amber-palette),
+      warn:    $red-palette,
+    )
+  )));
+}
+
+.dialogue {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+mat-dialog-content.dialogue {
+  height: 100%;
+  min-height: 100%;
+  max-height: 100%;
+  box-sizing: border-box;
+}
+
+.conteneur-docplan {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  height: 100%;
+  min-height: 100%;
+  overflow: hidden;
+}
+
+.connaitre {
+  padding-bottom: 15px;
+  @include bandeau($connaitre);
+}
+
+.docplan {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 24px;
+}
+
+.button-title {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+
+  .form-buttons {
+    flex-shrink: 0;
+  }
+
+  .title-container {
+    flex: 1;
+
+    h2 {
+      margin: 0;
+      font-size: 1.1rem;
+      font-weight: 500;
+    }
+  }
+}
+
+.full-width {
+  width: 100%;
+  display: block;
+}
+
+.form-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+
+  mat-form-field {
+    flex: 1;
+    min-width: 140px;
+  }
+}
+
+.custom-mat-form-field {
+  display: inline-flex;
+  margin-right: 12px;
+  margin-bottom: 4px;
+}
+
+.note-info {
+  font-size: 0.8rem;
+  color: #555;
+  font-style: italic;
+  margin: 16px 0;
+  border-left: 3px solid #1565c0;
+  padding-left: 10px;
+  line-height: 1.4;
+}
+
+// --- Section Unités de gestion ---
+
+.ug-section {
+  margin-top: 16px;
+
+  .ug-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+
+    h3 {
+      margin: 0;
+      font-size: 0.95rem;
+      font-weight: 500;
+    }
+  }
+
+  mat-table {
+    width: 100%;
+    margin-bottom: 8px;
+  }
+
+  .no-ug {
+    font-size: 0.85rem;
+    color: #888;
+    font-style: italic;
+    margin: 4px 0 12px 0;
+  }
+}
+
+.ug-add-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 8px;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  margin-top: 8px;
+
+  .ug-field {
+    flex: 1;
+    min-width: 120px;
+  }
+
+  .ug-field-surface {
+    flex: 0 0 120px;
+  }
+}
+
+// --- Lien de téléchargement du document PDF ---
+
+.download-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  margin: 8px 0 4px 0;
+  background-color: #eaf4fb;
+  border-left: 3px solid $bleuM;
+  border-radius: 4px;
+  font-size: 0.95rem;
+  color: $bleuM;
+
+  a {
+    color: $bleuM;
+    text-decoration: none;
+    font-weight: 500;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  &.no-pdf {
+    color: #888;
+    border-left-color: #ccc;
+    background-color: #f5f5f5;
+    font-style: italic;
+  }
+}
+
+// --- Spinner ---
+
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  gap: 16px;
+
+  p {
+    color: #666;
+  }
+}

--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.ts
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.ts
@@ -1,0 +1,236 @@
+import { Component, OnInit, OnDestroy, ChangeDetectorRef, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { Subscription } from 'rxjs';
+
+import { DocPlanDetail, UniteGestion } from '../docplan';
+import { SelectValue } from '../../../../shared/interfaces/formValues';
+
+import { FormService } from '../../../../shared/services/form.service';
+import { SitesService } from '../../../sites.service';
+import { ConfirmationService } from '../../../../shared/services/confirmation.service';
+import { LoginService } from '../../../../login/login.service';
+import { FormButtonsComponent } from '../../../../shared/form-buttons/form-buttons.component';
+
+import {
+  MatDialogRef,
+  MatDialogModule,
+  MatDialogContent,
+  MAT_DIALOG_DATA,
+} from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-docplan-fiche',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormButtonsComponent,
+    MatDialogModule,
+    MatDialogContent,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+    MatTableModule,
+    FormsModule,
+    ReactiveFormsModule,
+  ],
+  templateUrl: './docplan-fiche.component.html',
+  styleUrls: ['./docplan-fiche.component.scss'],
+})
+export class DocPlanFicheComponent implements OnInit, OnDestroy {
+  docPlanDetail?: DocPlanDetail;
+  unitesGestion: UniteGestion[] = [];
+  ugDataSource!: MatTableDataSource<UniteGestion>;
+  ugColumns: string[] = ['code', 'nom', 'surface', 'actions'];
+
+  isNewDoc: boolean = false;
+  isEditMode: boolean = false;
+  isLoading: boolean = true;
+
+  docPlanForm!: FormGroup;
+  initialFormValues!: any;
+  isFormValid: boolean = false;
+
+  isAddingUG: boolean = false;
+  ugForm!: FormGroup;
+
+  typesDocument: SelectValue[] = [];
+
+  actuelOptions: SelectValue[] = [
+    { cd_type: 'Oui', libelle: 'Oui' },
+    { cd_type: 'Non', libelle: 'Non' },
+  ];
+
+  private formStatusSub: Subscription | null = null;
+
+  constructor(
+    private dialogRef: MatDialogRef<DocPlanFicheComponent>,
+    private sitesService: SitesService,
+    private formService: FormService,
+    private confirmationService: ConfirmationService,
+    private snackBar: MatSnackBar,
+    private loginService: LoginService,
+    private cdr: ChangeDetectorRef,
+    @Inject(MAT_DIALOG_DATA) public data: { uuid_doc?: string; uuid_site: string }
+  ) {}
+
+  get isAdmin(): boolean {
+    return (this.loginService.user()?.gro_id ?? 0) > 2;
+  }
+
+  async ngOnInit() {
+    this.formService
+      .getSelectValues$('sites/selectvalues=docplan.typ_documents')
+      .subscribe({
+        next: (values: SelectValue[] | undefined) => (this.typesDocument = values || []),
+        error: (err: unknown) => console.error('Erreur chargement types documents', err),
+      });
+
+    if (this.data.uuid_doc) {
+      try {
+        this.docPlanDetail = await this.sitesService.getDocPlanDetail(this.data.uuid_doc);
+        this.unitesGestion = await this.sitesService.getDocPlanUG(this.data.uuid_doc);
+        this.ugDataSource = new MatTableDataSource(this.unitesGestion);
+
+        this.docPlanForm = this.formService.newDocPlanForm(this.docPlanDetail, this.data.uuid_site);
+        this.initialFormValues = this.docPlanForm.getRawValue();
+        this.docPlanForm.disable();
+      } catch (error) {
+        console.error('Erreur chargement document planificateur', error);
+      }
+    } else {
+      this.isNewDoc = true;
+      this.isEditMode = true;
+      this.docPlanForm = this.formService.newDocPlanForm(undefined, this.data.uuid_site);
+      this.ugDataSource = new MatTableDataSource<UniteGestion>([]);
+    }
+
+    this.formStatusSub = this.docPlanForm.statusChanges.subscribe(() => {
+      this.isFormValid = this.docPlanForm.valid;
+      this.cdr.detectChanges();
+    });
+
+    this.isLoading = false;
+    this.cdr.detectChanges();
+  }
+
+  ngOnDestroy(): void {
+    this.formStatusSub?.unsubscribe();
+  }
+
+  toggleEdit(): void {
+    this.isEditMode = this.formService.simpleToggle(this.isEditMode);
+    if (this.isEditMode) {
+      this.docPlanForm.enable();
+      if (!this.isAdmin) {
+        this.docPlanForm.get('url')?.disable();
+      }
+    } else {
+      this.docPlanForm.patchValue(this.initialFormValues);
+      this.docPlanForm.disable();
+    }
+    this.cdr.detectChanges();
+  }
+
+  onSubmit(): void {
+    const mode = this.isNewDoc ? 'insert' : 'update';
+    const uuid = this.isNewDoc ? undefined : this.docPlanDetail?.uuid_doc;
+
+    const obs = this.formService.putBdd(
+      mode,
+      'docplan_documents',
+      this.docPlanForm,
+      this.isEditMode,
+      this.snackBar,
+      uuid,
+      this.initialFormValues
+    );
+
+    if (obs) {
+      obs.subscribe({
+        next: (result: { isEditMode: boolean; formValue: any; skipped?: boolean }) => {
+          this.isEditMode = result.isEditMode;
+          if (!result.skipped) {
+            this.initialFormValues = result.formValue;
+            if (this.isNewDoc) {
+              this.isNewDoc = false;
+              this.docPlanDetail = result.formValue as DocPlanDetail;
+            }
+          }
+          this.cdr.detectChanges();
+        },
+        error: (err: unknown) => console.error('Erreur sauvegarde document planificateur', err),
+      });
+    }
+  }
+
+  getTypDocLibelle(cd_type: string | null): string {
+    if (!cd_type) return 'Non renseigné';
+    return this.formService.getLibelleByCdType(cd_type, this.typesDocument) || cd_type;
+  }
+
+  // Gestion des unités de gestion
+
+  startAddUG(): void {
+    const uuid_doc = this.docPlanForm.get('uuid_doc')?.value;
+    if (!uuid_doc) return;
+    this.ugForm = this.formService.newUniteGestionForm(uuid_doc);
+    this.isAddingUG = true;
+  }
+
+  cancelAddUG(): void {
+    this.isAddingUG = false;
+  }
+
+  saveUG(): void {
+    const ugData: UniteGestion = this.ugForm.value;
+    this.sitesService.insertTable('docplan_unites_gestion', ugData).subscribe({
+      next: () => {
+        this.unitesGestion = [...this.unitesGestion, ugData];
+        this.ugDataSource = new MatTableDataSource(this.unitesGestion);
+        this.isAddingUG = false;
+        this.snackBar.open("Unité de gestion ajoutée", 'Fermer', {
+          duration: 3000,
+          panelClass: ['snackbar-success'],
+        });
+      },
+      error: (err) => console.error("Erreur lors de l'ajout de l'unité de gestion", err),
+    });
+  }
+
+  deleteUG(ug: UniteGestion): void {
+    this.confirmationService
+      .confirm(
+        'Suppression',
+        `Supprimer l'unité de gestion "${ug.code || ug.nom}" ?<br><strong>Cette action est irréversible.</strong>`,
+        'delete'
+      )
+      .subscribe((confirmed: boolean | string[]) => {
+        if (!confirmed || Array.isArray(confirmed)) return;
+        this.sitesService.deleteDocPlanUG(ug.uuid_ug).subscribe({
+          next: () => {
+            this.unitesGestion = this.unitesGestion.filter((u) => u.uuid_ug !== ug.uuid_ug);
+            this.ugDataSource = new MatTableDataSource(this.unitesGestion);
+            this.snackBar.open('Unité de gestion supprimée', 'Fermer', {
+              duration: 3000,
+              panelClass: ['snackbar-success'],
+            });
+          },
+          error: (err: unknown) => console.error('Erreur suppression unité de gestion', err),
+        });
+      });
+  }
+}

--- a/src/app/sites/site-detail/detail-gestion/docplan.ts
+++ b/src/app/sites/site-detail/detail-gestion/docplan.ts
@@ -1,9 +1,35 @@
+// Liste des documents planificateurs d'un site (vue docplan.docplanifsites)
 export interface DocPlan {
     uuid_doc: string;
     document: string;
-    annee_deb: string;
-    annee_fin: string;
+    annee_deb: number;
+    annee_fin: number | null;
     docactuel: string;
-    url: string;
-    surface: string; 
+    url: string | null;
+    surface: number | null;
+}
+
+// Détail complet d'un document planificateur (table docplan.documents)
+export interface DocPlanDetail {
+    uuid_doc: string;
+    nom: string;
+    surface: number | null;
+    annee_deb: number;
+    annee_fin: number | null;
+    validite: boolean;
+    url: string | null;
+    site: string | null;
+    entite_coherente: string | null;
+    typ_document: string | null;
+    actuel: string | null;
+    evaluation: number | null;
+}
+
+// Unité de gestion liée à un document planificateur (table docplan.unites_gestion)
+export interface UniteGestion {
+    uuid_ug: string;
+    code: string | null;
+    nom: string | null;
+    surface: number | null;
+    document: string;
 }

--- a/src/app/sites/sites.service.ts
+++ b/src/app/sites/sites.service.ts
@@ -8,7 +8,7 @@ import { of, from, Observable } from 'rxjs';
 // interfaces utilisés dans la promise de la fonction
 import { ListSite } from './site'; // prototype d'un site
 import { Commune } from './site-detail/detail-infos/commune';
-import { DocPlan } from './site-detail/detail-gestion/docplan';
+import { DocPlan, DocPlanDetail, UniteGestion } from './site-detail/detail-gestion/docplan';
 import { MilNat } from './site-detail/detail-habitats/docmilnat';
 import { Acte } from './site-detail/detail-mfu/acte';
 import { ProjetLite } from './site-detail/detail-projets/projets';
@@ -63,6 +63,24 @@ export class SitesService {
 
   async getDocPlan(subroute: string): Promise<DocPlan[]> {
     return this.getData<DocPlan[]>(subroute);
+  }
+
+  async getDocPlanDetail(uuid_doc: string): Promise<DocPlanDetail> {
+    return this.getData<DocPlanDetail>(`pgestion/doc/uuid=${uuid_doc}`);
+  }
+
+  async getDocPlanUG(uuid_doc: string): Promise<UniteGestion[]> {
+    return this.getData<UniteGestion[]>(`pgestion/doc/uuid=${uuid_doc}/ug`);
+  }
+
+  deleteDocPlanUG(uuid_ug: string): Observable<any> {
+    const url = `${this.activeUrl}delete/docplan_unites_gestion/uuid_ug=${uuid_ug}`;
+    return this.http.delete<any>(url).pipe(
+      catchError(error => {
+        console.error('Erreur lors de la suppression de l\'unité de gestion', error);
+        throw error;
+      })
+    );
   }
 
   async getMilNat(subroute: string): Promise<MilNat[]> {

--- a/src/app/styles/themes.scss
+++ b/src/app/styles/themes.scss
@@ -61,8 +61,35 @@ $custom-red: (
   )
 );
 
+// Palette bleue basée sur $connaitre ($bleuC / $bleuM / $bleuF)
+$custom-connaitre: (
+  50:  lighten($bleuC, 18%),
+  100: lighten($bleuC, 12%),
+  200: lighten($bleuC, 6%),
+  300: $bleuC,
+  400: darken($bleuC, 6%),
+  500: $bleuM,
+  600: darken($bleuM, 5%),
+  700: darken($bleuM, 12%),
+  800: $bleuF,
+  900: darken($bleuF, 10%),
+  contrast: (
+    50:  rgba(black, 0.87),
+    100: rgba(black, 0.87),
+    200: rgba(black, 0.87),
+    300: rgba(black, 0.87),
+    400: rgba(black, 0.87),
+    500: white,
+    600: white,
+    700: white,
+    800: white,
+    900: white,
+  )
+);
+
 // Création des palettes
 $gerer-palette: mat.m2-define-palette($custom-gerer);
+$connaitre-palette: mat.m2-define-palette($custom-connaitre, 500, 300, 700);
 $red-palette: mat.m2-define-palette($custom-red);
 
 // Thème associé à la palette gerer


### PR DESCRIPTION
- Refonte de detail-gestion : tableau des docplans avec tri, filtre et PDF
- Nouveau composant DocPlanFicheComponent (dialog) : consultation/édition d'un document planificateur avec gestion des unités de gestion (UG)
- Nouveau module /docplan : recherche multi-critères et liste paginée de tous les documents planificateurs, avec ouverture de la fiche via dialog
- FormService : ajout des builders newDocPlanForm et newUniteGestionForm
- SitesService : ajout getDocPlanDetail, getDocPlanUG, deleteDocPlanUG, insertTable
- app.routes.ts : route lazy-loaded /docplan
- Correction MatSort (ViewChild setter) dans DocplanDisplayComponent