### PR TITLE
feat(gestion): ajouter la gestion des entités cohérentes de gestion (…

### DIFF
--- a/src/app/shared/services/form.service.ts
+++ b/src/app/shared/services/form.service.ts
@@ -535,6 +535,13 @@ export class FormService {
     });
   }
 
+  newEntiteCoherenteForm(): FormGroup {
+    return this.fb.group({
+      uuid_ecg: [uuidv4()],
+      nom: ['', Validators.required],
+    });
+  }
+
   newShapeForm(uuid_ope: string, type_geometry: string): FormGroup {
     return this.fb.group({
       uuid_ope: [uuid_ope || null, Validators.required],

--- a/src/app/sites/docplan/docplan.component.html
+++ b/src/app/sites/docplan/docplan.component.html
@@ -1,5 +1,5 @@
 <div class="site-parent">
-  <div class="proteger">Documents de plans de gestion</div>
+  <div class="connaitre">Documents de plans de gestion</div>
 
   <div class="sites-enfants">
     <app-docplan-research></app-docplan-research>

--- a/src/app/sites/docplan/docplan.component.scss
+++ b/src/app/sites/docplan/docplan.component.scss
@@ -9,9 +9,9 @@
 	min-height: 100vh;
 }
 
-.proteger {
+.connaitre {
 	padding-bottom: 15px;
-	@include bandeau($couleur-flore);
+	@include bandeau($connaitre);
 }
 
 .sites-enfants {

--- a/src/app/sites/docplan/ecg-picker/ecg-picker.component.html
+++ b/src/app/sites/docplan/ecg-picker/ecg-picker.component.html
@@ -1,0 +1,91 @@
+<mat-dialog-content class="ecg-picker">
+
+  <ng-container *ngIf="!isCreating; else creationTemplate">
+
+    <div class="ecg-header">
+      <h2>Entités cohérentes de gestion</h2>
+      <button mat-mini-fab color="primary"
+              type="button"
+              matTooltip="Créer une nouvelle entité cohérente"
+              (click)="startCreate()">
+        <mat-icon>add</mat-icon>
+      </button>
+    </div>
+
+    <div *ngIf="isLoading" class="loading-container">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+
+    <ng-container *ngIf="!isLoading && dataSource">
+
+      <mat-form-field class="filter-field">
+        <mat-label>Rechercher</mat-label>
+        <input matInput (keyup)="applyFilter($event)" placeholder="Nom, site...">
+        <mat-icon matSuffix>search</mat-icon>
+      </mat-form-field>
+
+      <mat-table [dataSource]="dataSource" class="mat-elevation-z2">
+
+        <ng-container matColumnDef="nom_ecg">
+          <mat-header-cell *matHeaderCellDef>Entité cohérente</mat-header-cell>
+          <mat-cell *matCellDef="let ecg">{{ ecg.nom_ecg }}</mat-cell>
+        </ng-container>
+
+        <ng-container matColumnDef="sites">
+          <mat-header-cell *matHeaderCellDef>Sites concernés</mat-header-cell>
+          <mat-cell *matCellDef="let ecg" class="sites-cell">
+            {{ ecg.nom || '—' }}
+          </mat-cell>
+        </ng-container>
+
+        <ng-container matColumnDef="action">
+          <mat-header-cell *matHeaderCellDef></mat-header-cell>
+          <mat-cell *matCellDef="let ecg">
+            <button mat-stroked-button color="primary"
+                    type="button"
+                    (click)="select(ecg)">
+              Définir
+            </button>
+          </mat-cell>
+        </ng-container>
+
+        <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+        <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+      </mat-table>
+
+      <p class="no-data" *ngIf="entites.length === 0">
+        Aucune entité cohérente de gestion enregistrée.
+      </p>
+
+    </ng-container>
+
+  </ng-container>
+
+  <ng-template #creationTemplate>
+
+    <div class="ecg-header">
+      <h2>Nouvelle entité cohérente de gestion</h2>
+    </div>
+
+    <form [formGroup]="ecgForm" class="creation-form">
+      <mat-form-field class="full-width">
+        <mat-label>Nom de l'entité cohérente *</mat-label>
+        <input matInput formControlName="nom">
+        <mat-error *ngIf="ecgForm.get('nom')?.hasError('required')">Champ obligatoire</mat-error>
+      </mat-form-field>
+    </form>
+
+    <div class="creation-actions">
+      <button mat-stroked-button type="button" (click)="cancelCreate()">
+        <mat-icon>arrow_back</mat-icon> Retour à la liste
+      </button>
+      <button mat-flat-button color="primary" type="button"
+              [disabled]="!ecgForm.valid"
+              (click)="saveCreate()">
+        <mat-icon>check</mat-icon> Créer et définir
+      </button>
+    </div>
+
+  </ng-template>
+
+</mat-dialog-content>

--- a/src/app/sites/docplan/ecg-picker/ecg-picker.component.scss
+++ b/src/app/sites/docplan/ecg-picker/ecg-picker.component.scss
@@ -1,0 +1,56 @@
+@import "../../../styles/variables.scss";
+
+.ecg-picker {
+  min-width: 500px;
+  padding: 16px;
+}
+
+.ecg-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+
+  h2 {
+    margin: 0;
+  }
+}
+
+.filter-field {
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.sites-cell {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.85em;
+  white-space: normal;
+}
+
+.no-data {
+  color: rgba(0, 0, 0, 0.5);
+  font-style: italic;
+  text-align: center;
+  margin-top: 16px;
+}
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  padding: 32px;
+}
+
+.creation-form {
+  margin-top: 8px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.creation-actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 16px;
+  gap: 12px;
+}

--- a/src/app/sites/docplan/ecg-picker/ecg-picker.component.ts
+++ b/src/app/sites/docplan/ecg-picker/ecg-picker.component.ts
@@ -1,0 +1,103 @@
+import { Component, OnInit, ChangeDetectorRef, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { EntiteCoherente } from '../../site-detail/detail-gestion/docplan';
+import { SitesService } from '../../sites.service';
+import { FormService } from '../../../shared/services/form.service';
+
+import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-ecg-picker',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './ecg-picker.component.html',
+  styleUrl: './ecg-picker.component.scss',
+})
+export class EcgPickerComponent implements OnInit {
+  entites: EntiteCoherente[] = [];
+  dataSource!: MatTableDataSource<EntiteCoherente>;
+  displayedColumns: string[] = ['nom_ecg', 'sites', 'action'];
+
+  isLoading = true;
+  isCreating = false;
+  ecgForm!: FormGroup;
+
+  private sitesService = inject(SitesService);
+  private formService = inject(FormService);
+  private snackBar = inject(MatSnackBar);
+  private cdr = inject(ChangeDetectorRef);
+
+  constructor(private dialogRef: MatDialogRef<EcgPickerComponent>) {}
+
+  async ngOnInit() {
+    try {
+      this.entites = await this.sitesService.getEntitesCoherentes();
+      this.dataSource = new MatTableDataSource(this.entites);
+    } catch (err) {
+      console.error('Erreur chargement entités cohérentes', err);
+    } finally {
+      this.isLoading = false;
+      this.cdr.detectChanges();
+    }
+  }
+
+  applyFilter(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = value.trim().toLowerCase();
+  }
+
+  select(ecg: EntiteCoherente): void {
+    this.dialogRef.close(ecg);
+  }
+
+  startCreate(): void {
+    this.ecgForm = this.formService.newEntiteCoherenteForm();
+    this.isCreating = true;
+  }
+
+  cancelCreate(): void {
+    this.isCreating = false;
+  }
+
+  saveCreate(): void {
+    if (!this.ecgForm.valid) return;
+
+    this.sitesService.insertTable('docplan_entites_coherentes', this.ecgForm.value).subscribe({
+      next: () => {
+        const newEcg: EntiteCoherente = {
+          uuid_ecg: this.ecgForm.value.uuid_ecg,
+          nom_ecg: this.ecgForm.value.nom,
+          nom: null,
+        };
+        this.snackBar.open('Entité cohérente créée', 'Fermer', {
+          duration: 3000,
+          panelClass: ['snackbar-success'],
+        });
+        this.dialogRef.close(newEcg);
+      },
+      error: (err) => console.error('Erreur création ECG', err),
+    });
+  }
+}

--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.html
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.html
@@ -147,96 +147,42 @@
     </form>
   </ng-container>
 
-  <!-- Note informative -->
+  <!-- ==============================
+       NOTE INFORMATIVE
+  =============================== -->
   <p class="note-info">
     Un document planificateur peut être associé à un ou plusieurs sites. S'il concerne plusieurs sites,
     on considère que ces sites constituent une entité cohérente de gestion (qu'ils soient nommés ainsi
     sur le document ou non). Il ne faut donc pas créer plusieurs fois le même document, mais indiquer
-    dans le champ ci-dessous l'entité cohérente de gestion correspondante, après l'avoir créée.
+    ci-dessous l'entité cohérente de gestion correspondante, après l'avoir créée si besoin.
   </p>
 
   <!-- ==============================
-       UNITÉS DE GESTION
+       ENTITÉ COHÉRENTE DE GESTION
   =============================== -->
-  <div class="ug-section">
+  <div class="ecg-section">
 
-    <div class="ug-header">
-      <h3>Unités de gestion</h3>
-      <button mat-icon-button type="button"
-              matTooltip="Ajouter une unité de gestion"
-              *ngIf="isEditMode && !isAddingUG"
-              (click)="startAddUG()">
-        <mat-icon>add</mat-icon>
+    <div class="ecg-header">
+      <h3>Entité cohérente de gestion</h3>
+      <button mat-stroked-button type="button"
+              *ngIf="isEditMode"
+              (click)="openEcgPicker()">
+        <mat-icon>link</mat-icon>
+        Assigner une entité cohérente
       </button>
     </div>
 
-    <mat-table [dataSource]="ugDataSource" class="mat-elevation-z2"
-               *ngIf="unitesGestion.length > 0 || isAddingUG">
-
-      <ng-container matColumnDef="code">
-        <mat-header-cell *matHeaderCellDef>Code UG</mat-header-cell>
-        <mat-cell *matCellDef="let ug">{{ ug.code }}</mat-cell>
-      </ng-container>
-
-      <ng-container matColumnDef="nom">
-        <mat-header-cell *matHeaderCellDef>Nom</mat-header-cell>
-        <mat-cell *matCellDef="let ug">{{ ug.nom }}</mat-cell>
-      </ng-container>
-
-      <ng-container matColumnDef="surface">
-        <mat-header-cell *matHeaderCellDef>Surface (ha)</mat-header-cell>
-        <mat-cell *matCellDef="let ug">{{ ug.surface }}</mat-cell>
-      </ng-container>
-
-      <ng-container matColumnDef="actions">
-        <mat-header-cell *matHeaderCellDef></mat-header-cell>
-        <mat-cell *matCellDef="let ug">
-          <button mat-icon-button color="warn"
-                  *ngIf="isEditMode"
-                  matTooltip="Supprimer cette unité de gestion"
-                  (click)="deleteUG(ug)">
-            <mat-icon>delete</mat-icon>
-          </button>
-        </mat-cell>
-      </ng-container>
-
-      <mat-header-row *matHeaderRowDef="ugColumns"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: ugColumns"></mat-row>
-    </mat-table>
-
-    <p class="no-ug" *ngIf="unitesGestion.length === 0 && !isAddingUG">
-      Aucune unité de gestion enregistrée.
-    </p>
-
-    <!-- Formulaire d'ajout d'une UG -->
-    <div *ngIf="isAddingUG" class="ug-add-form" [formGroup]="ugForm">
-      <mat-form-field class="ug-field">
-        <mat-label>Code UG</mat-label>
-        <input matInput formControlName="code">
-      </mat-form-field>
-
-      <mat-form-field class="ug-field">
-        <mat-label>Nom</mat-label>
-        <input matInput formControlName="nom">
-      </mat-form-field>
-
-      <mat-form-field class="ug-field-surface">
-        <mat-label>Surface (ha)</mat-label>
-        <input matInput type="number" step="0.0001" formControlName="surface">
-      </mat-form-field>
-
-      <button mat-icon-button color="primary" type="button"
-              matTooltip="Valider l'ajout"
-              (click)="saveUG()">
-        <mat-icon>check</mat-icon>
-      </button>
-
-      <button mat-icon-button type="button"
-              matTooltip="Annuler"
-              (click)="cancelAddUG()">
-        <mat-icon>close</mat-icon>
-      </button>
+    <div class="ecg-courante" *ngIf="ecgCourante; else noEcg">
+      <mat-icon class="ecg-icon">account_tree</mat-icon>
+      <div class="ecg-info">
+        <span class="ecg-nom">{{ ecgCourante.nom_ecg }}</span>
+        <span class="ecg-sites" *ngIf="ecgCourante.nom">Sites : {{ ecgCourante.nom }}</span>
+      </div>
     </div>
+
+    <ng-template #noEcg>
+      <p class="no-ecg">Aucune entité cohérente de gestion assignée.</p>
+    </ng-template>
 
   </div>
 

--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.scss
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.scss
@@ -99,16 +99,16 @@ mat-dialog-content.dialogue {
   line-height: 1.4;
 }
 
-// --- Section Unités de gestion ---
+// --- Section Entité cohérente de gestion ---
 
-.ug-section {
+.ecg-section {
   margin-top: 16px;
 
-  .ug-header {
+  .ecg-header {
     display: flex;
     align-items: center;
-    gap: 8px;
-    margin-bottom: 8px;
+    justify-content: space-between;
+    margin-bottom: 12px;
 
     h3 {
       margin: 0;
@@ -116,38 +116,45 @@ mat-dialog-content.dialogue {
       font-weight: 500;
     }
   }
+}
 
-  mat-table {
-    width: 100%;
-    margin-bottom: 8px;
+.ecg-courante {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  background-color: #eaf4fb;
+  border-left: 3px solid $connaitre;
+  border-radius: 4px;
+
+  .ecg-icon {
+    color: $connaitre;
+    margin-top: 2px;
   }
 
-  .no-ug {
-    font-size: 0.85rem;
-    color: #888;
-    font-style: italic;
-    margin: 4px 0 12px 0;
+  .ecg-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    .ecg-nom {
+      font-weight: 500;
+      font-size: 0.95rem;
+    }
+
+    .ecg-sites {
+      font-size: 0.82rem;
+      color: #555;
+      font-style: italic;
+    }
   }
 }
 
-.ug-add-form {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  padding: 8px;
-  background-color: #f5f5f5;
-  border-radius: 4px;
-  margin-top: 8px;
-
-  .ug-field {
-    flex: 1;
-    min-width: 120px;
-  }
-
-  .ug-field-surface {
-    flex: 0 0 120px;
-  }
+.no-ecg {
+  font-size: 0.85rem;
+  color: #888;
+  font-style: italic;
+  margin: 4px 0;
 }
 
 // --- Lien de téléchargement du document PDF ---

--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.ts
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
-import { DocPlanDetail, UniteGestion } from '../docplan';
+import { DocPlanDetail, EntiteCoherente } from '../docplan';
 import { SelectValue } from '../../../../shared/interfaces/formValues';
 
 import { FormService } from '../../../../shared/services/form.service';
@@ -11,12 +11,14 @@ import { SitesService } from '../../../sites.service';
 import { ConfirmationService } from '../../../../shared/services/confirmation.service';
 import { LoginService } from '../../../../login/login.service';
 import { FormButtonsComponent } from '../../../../shared/form-buttons/form-buttons.component';
+import { EcgPickerComponent } from '../../../docplan/ecg-picker/ecg-picker.component';
 
 import {
   MatDialogRef,
   MatDialogModule,
   MatDialogContent,
   MAT_DIALOG_DATA,
+  MatDialog,
 } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -25,8 +27,8 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Overlay } from '@angular/cdk/overlay';
 
 @Component({
   selector: 'app-docplan-fiche',
@@ -43,7 +45,6 @@ import { MatSnackBar } from '@angular/material/snack-bar';
     MatTooltipModule,
     MatButtonModule,
     MatProgressSpinnerModule,
-    MatTableModule,
     FormsModule,
     ReactiveFormsModule,
   ],
@@ -52,9 +53,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 })
 export class DocPlanFicheComponent implements OnInit, OnDestroy {
   docPlanDetail?: DocPlanDetail;
-  unitesGestion: UniteGestion[] = [];
-  ugDataSource!: MatTableDataSource<UniteGestion>;
-  ugColumns: string[] = ['code', 'nom', 'surface', 'actions'];
+  ecgCourante?: EntiteCoherente;
 
   isNewDoc: boolean = false;
   isEditMode: boolean = false;
@@ -63,9 +62,6 @@ export class DocPlanFicheComponent implements OnInit, OnDestroy {
   docPlanForm!: FormGroup;
   initialFormValues!: any;
   isFormValid: boolean = false;
-
-  isAddingUG: boolean = false;
-  ugForm!: FormGroup;
 
   typesDocument: SelectValue[] = [];
 
@@ -78,6 +74,8 @@ export class DocPlanFicheComponent implements OnInit, OnDestroy {
 
   constructor(
     private dialogRef: MatDialogRef<DocPlanFicheComponent>,
+    private dialog: MatDialog,
+    private overlay: Overlay,
     private sitesService: SitesService,
     private formService: FormService,
     private confirmationService: ConfirmationService,
@@ -102,12 +100,13 @@ export class DocPlanFicheComponent implements OnInit, OnDestroy {
     if (this.data.uuid_doc) {
       try {
         this.docPlanDetail = await this.sitesService.getDocPlanDetail(this.data.uuid_doc);
-        this.unitesGestion = await this.sitesService.getDocPlanUG(this.data.uuid_doc);
-        this.ugDataSource = new MatTableDataSource(this.unitesGestion);
-
         this.docPlanForm = this.formService.newDocPlanForm(this.docPlanDetail, this.data.uuid_site);
         this.initialFormValues = this.docPlanForm.getRawValue();
         this.docPlanForm.disable();
+
+        if (this.docPlanDetail.entite_coherente) {
+          await this.loadEcgCourante(this.docPlanDetail.entite_coherente);
+        }
       } catch (error) {
         console.error('Erreur chargement document planificateur', error);
       }
@@ -115,7 +114,6 @@ export class DocPlanFicheComponent implements OnInit, OnDestroy {
       this.isNewDoc = true;
       this.isEditMode = true;
       this.docPlanForm = this.formService.newDocPlanForm(undefined, this.data.uuid_site);
-      this.ugDataSource = new MatTableDataSource<UniteGestion>([]);
     }
 
     this.formStatusSub = this.docPlanForm.statusChanges.subscribe(() => {
@@ -129,6 +127,15 @@ export class DocPlanFicheComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.formStatusSub?.unsubscribe();
+  }
+
+  private async loadEcgCourante(uuid_ecg: string): Promise<void> {
+    try {
+      const toutes = await this.sitesService.getEntitesCoherentes();
+      this.ecgCourante = toutes.find(e => e.uuid_ecg === uuid_ecg);
+    } catch (err) {
+      console.error('Erreur chargement ECG courante', err);
+    }
   }
 
   toggleEdit(): void {
@@ -182,55 +189,23 @@ export class DocPlanFicheComponent implements OnInit, OnDestroy {
     return this.formService.getLibelleByCdType(cd_type, this.typesDocument) || cd_type;
   }
 
-  // Gestion des unités de gestion
+  // Gestion de l'entité cohérente de gestion
 
-  startAddUG(): void {
-    const uuid_doc = this.docPlanForm.get('uuid_doc')?.value;
-    if (!uuid_doc) return;
-    this.ugForm = this.formService.newUniteGestionForm(uuid_doc);
-    this.isAddingUG = true;
-  }
-
-  cancelAddUG(): void {
-    this.isAddingUG = false;
-  }
-
-  saveUG(): void {
-    const ugData: UniteGestion = this.ugForm.value;
-    this.sitesService.insertTable('docplan_unites_gestion', ugData).subscribe({
-      next: () => {
-        this.unitesGestion = [...this.unitesGestion, ugData];
-        this.ugDataSource = new MatTableDataSource(this.unitesGestion);
-        this.isAddingUG = false;
-        this.snackBar.open("Unité de gestion ajoutée", 'Fermer', {
-          duration: 3000,
-          panelClass: ['snackbar-success'],
-        });
-      },
-      error: (err) => console.error("Erreur lors de l'ajout de l'unité de gestion", err),
+  openEcgPicker(): void {
+    const dialogRef = this.dialog.open(EcgPickerComponent, {
+      minWidth: '550px',
+      maxWidth: '90vw',
+      maxHeight: '80vh',
+      hasBackdrop: true,
+      scrollStrategy: this.overlay.scrollStrategies.close(),
     });
-  }
 
-  deleteUG(ug: UniteGestion): void {
-    this.confirmationService
-      .confirm(
-        'Suppression',
-        `Supprimer l'unité de gestion "${ug.code || ug.nom}" ?<br><strong>Cette action est irréversible.</strong>`,
-        'delete'
-      )
-      .subscribe((confirmed: boolean | string[]) => {
-        if (!confirmed || Array.isArray(confirmed)) return;
-        this.sitesService.deleteDocPlanUG(ug.uuid_ug).subscribe({
-          next: () => {
-            this.unitesGestion = this.unitesGestion.filter((u) => u.uuid_ug !== ug.uuid_ug);
-            this.ugDataSource = new MatTableDataSource(this.unitesGestion);
-            this.snackBar.open('Unité de gestion supprimée', 'Fermer', {
-              duration: 3000,
-              panelClass: ['snackbar-success'],
-            });
-          },
-          error: (err: unknown) => console.error('Erreur suppression unité de gestion', err),
-        });
-      });
+    dialogRef.afterClosed().subscribe((ecg: EntiteCoherente | undefined) => {
+      if (ecg) {
+        this.ecgCourante = ecg;
+        this.docPlanForm.patchValue({ entite_coherente: ecg.uuid_ecg });
+        this.cdr.detectChanges();
+      }
+    });
   }
 }

--- a/src/app/sites/site-detail/detail-gestion/docplan.ts
+++ b/src/app/sites/site-detail/detail-gestion/docplan.ts
@@ -33,3 +33,10 @@ export interface UniteGestion {
     surface: number | null;
     document: string;
 }
+
+// Entité cohérente de gestion (vue docplan.listecg)
+export interface EntiteCoherente {
+    uuid_ecg: string;
+    nom_ecg: string;
+    nom: string | null; // sites associés concaténés
+}

--- a/src/app/sites/sites.service.ts
+++ b/src/app/sites/sites.service.ts
@@ -8,7 +8,7 @@ import { of, from, Observable } from 'rxjs';
 // interfaces utilisés dans la promise de la fonction
 import { ListSite } from './site'; // prototype d'un site
 import { Commune } from './site-detail/detail-infos/commune';
-import { DocPlan, DocPlanDetail, UniteGestion } from './site-detail/detail-gestion/docplan';
+import { DocPlan, DocPlanDetail, UniteGestion, EntiteCoherente } from './site-detail/detail-gestion/docplan';
 import { MilNat } from './site-detail/detail-habitats/docmilnat';
 import { Acte } from './site-detail/detail-mfu/acte';
 import { ProjetLite } from './site-detail/detail-projets/projets';
@@ -71,6 +71,10 @@ export class SitesService {
 
   async getDocPlanUG(uuid_doc: string): Promise<UniteGestion[]> {
     return this.getData<UniteGestion[]>(`pgestion/doc/uuid=${uuid_doc}/ug`);
+  }
+
+  async getEntitesCoherentes(): Promise<EntiteCoherente[]> {
+    return this.getData<EntiteCoherente[]>('pgestion/entites_coherentes');
   }
 
   deleteDocPlanUG(uuid_ug: string): Observable<any> {

--- a/src/app/styles/_variables.scss
+++ b/src/app/styles/_variables.scss
@@ -48,7 +48,7 @@ $superRed: rgb(223, 84, 84);
 // Couleur du menu
 $proteger: $couleur-faune; // Couleur de fond personnalisée
 
-$connaitre: $bleuC;
+$connaitre: $bleuM;
 
 $gerer: $couleur-territoire;
 $gererBackdrop: $blackGreen;


### PR DESCRIPTION
…ECG)

- Nouveau composant EcgPickerComponent (dialog) : liste des ECG avec leurs sites associés, bouton "Définir" par ligne, filtre de recherche, et formulaire de création inline via ng-template (sans navigation)
- docplan-fiche : suppression de la section unités de gestion (table obsolète), ajout du bloc ECG avec affichage de l'entité assignée et bouton d'assignation
- SitesService : ajout de getEntitesCoherentes() → GET sites/pgestion/entites_coherentes
- FormService : ajout de newEntiteCoherenteForm()
- docplan.ts : ajout de l'interface EntiteCoherente
- Correction bandeau /docplan : classe proteger → connaitre (bleu clair)