### PR TITLE
feat(ecg): finitions UX sur la gestion des entités cohérentes de gestion

### DIFF
--- a/src/app/sites/docplan/docplan-display/docplan-display.component.ts
+++ b/src/app/sites/docplan/docplan-display/docplan-display.component.ts
@@ -10,7 +10,6 @@ import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { Overlay } from '@angular/cdk/overlay';
 
 import { DocPlanListe } from '../docplan';
 import { DocplanService } from '../docplan.service';
@@ -65,7 +64,6 @@ export class DocplanDisplayComponent {
   private research: DocplanService = inject(DocplanService);
   private route: ActivatedRoute = inject(ActivatedRoute);
   private dialog: MatDialog = inject(MatDialog);
-  private overlay: Overlay = inject(Overlay);
 
   private loadDocplans(params: Params): void {
     const subroute =
@@ -131,7 +129,6 @@ export class DocplanDisplayComponent {
       backdropClass: 'custom-backdrop-gerer',
       enterAnimationDuration: '400ms',
       exitAnimationDuration: '300ms',
-      scrollStrategy: this.overlay.scrollStrategies.close(),
     });
 
     dialogRef.afterClosed().subscribe(() => {

--- a/src/app/sites/docplan/docplan-research/docplan-research.component.html
+++ b/src/app/sites/docplan/docplan-research/docplan-research.component.html
@@ -2,36 +2,49 @@
   <p *ngIf="selectorsError" class="selectors-error">
     Les filtres sont indisponibles (endpoint <code>pgestion/selectors</code> manquant côté backend).
   </p>
-  <div class="recherche">
-    <mat-form-field
-      *ngFor="let selector of selectors"
-      appearance="fill"
-      [ngClass]="[
-        'selecteur',
-        selector.name === 'localisation' ? 'selecteur-localisation' : ''
-      ]"
-    >
-      <mat-label ngClass="label">{{ selector.title }} :</mat-label>
-      <mat-select
-        id="{{ selector.name }}"
-        (selectionChange)="selectionSelectors($event, selector.name)"
-      >
-        <mat-option [value]="{ id: selector.name, name: selector.name }" selected>
-          Selectionner {{ selector.name }}
-        </mat-option>
-        <mat-option
-          *ngFor="let value of selector.values"
-          [value]="{ id: value, name: value }"
-        >
-          {{ value }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-  </div>
 
-  <div class="btn">
-    <button mat-button-flat (click)="docplanSelection()">
-      Sélection des documents
-    </button>
+  <div class="barre">
+
+    <div class="gauche">
+      <div class="recherche">
+        <mat-form-field
+          *ngFor="let selector of selectors"
+          appearance="fill"
+          [ngClass]="[
+            'selecteur',
+            selector.name === 'localisation' ? 'selecteur-localisation' : ''
+          ]"
+        >
+          <mat-label ngClass="label">{{ selector.title }} :</mat-label>
+          <mat-select
+            id="{{ selector.name }}"
+            (selectionChange)="selectionSelectors($event, selector.name)"
+          >
+            <mat-option [value]="{ id: selector.name, name: selector.name }" selected>
+              Selectionner {{ selector.name }}
+            </mat-option>
+            <mat-option
+              *ngFor="let value of selector.values"
+              [value]="{ id: value, name: value }"
+            >
+              {{ value }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+
+      <button mat-button-flat (click)="docplanSelection()">
+        Sélection des documents
+      </button>
+    </div>
+
+    <div class="droite">
+      <button mat-mini-fab color="primary"
+              matTooltip="Gérer les entités cohérentes de gestion"
+              (click)="openEcgManager()">
+        <mat-icon>account_tree</mat-icon>
+      </button>
+    </div>
+
   </div>
 </div>

--- a/src/app/sites/docplan/docplan-research/docplan-research.component.scss
+++ b/src/app/sites/docplan/docplan-research/docplan-research.component.scss
@@ -8,74 +8,78 @@
 }
 
 .conteneur {
-  @include dim(100%, auto);
-  display: grid;
-  grid-template-rows: 2fr 1fr;
-  flex-wrap: wrap;
+  width: 100%;
   padding-bottom: 20px;
   margin-bottom: 20px;
-  .recherche {
-    display: grid;
-    grid-template-columns: repeat(8, 1fr);
-    flex-wrap: wrap;
-    gap: 31px;
-    padding-top: 20px;
-    @include dim(auto, auto);
-    @include align(center, space-between);
-  }
+}
+
+.barre {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  padding-top: 20px;
+}
+
+.gauche {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.recherche {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 31px;
+
   .selecteur {
-    @include dim(100%, auto);
+    width: 100%;
   }
+
   .selecteur-localisation {
     grid-column: span 2;
   }
+
   .label {
     @include Typo($p14, $normal, $couleur-flore);
   }
-  .btn {
-    display: flex;
-    @include align(center, center);
-    margin: 0 40px 0 19px;
-    button {
-      @include btn($couleur-flore, white, white, $couleur-territoire);
-      @include align(center, center);
-    }
-  }
+}
+
+.gauche button {
+  @include btn($couleur-flore, white, white, $couleur-territoire);
+  align-self: flex-start;
+}
+
+.droite {
+  flex-shrink: 0;
+  align-self: center;
 }
 
 @media screen and (max-width: $mobile) {
-  .conteneur {
-    grid-template-rows: 1fr 30%;
-    padding-bottom: 10px;
-    margin-bottom: 20px;
-    .recherche {
-      grid-template-columns: 1fr 1fr;
-    }
-    .label {
-      font-size: $p12;
-    }
+  .barre {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 
-    .btn {
-      padding: 20px;
-      height: 30%;
-    }
+  .recherche {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .label {
+    font-size: $p12;
+  }
+
+  .droite {
+    align-self: flex-end;
   }
 }
 
 @media screen and (min-width: $mobile) and (max-width: $tablette) {
-  .conteneur {
-    grid-template-rows: 1fr 30%;
-    padding-bottom: 10px;
-    margin-bottom: 20px;
-    .recherche {
-      grid-template-columns: 1fr 1fr 1fr;
-    }
-    .label {
-      font-size: $p12;
-    }
+  .recherche {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
 
-    .btn {
-      height: 30%;
-    }
+  .label {
+    font-size: $p12;
   }
 }

--- a/src/app/sites/docplan/docplan-research/docplan-research.component.ts
+++ b/src/app/sites/docplan/docplan-research/docplan-research.component.ts
@@ -4,10 +4,15 @@ import { Router } from '@angular/router';
 
 import { Selector } from '../../../shared/interfaces/selector';
 import { DocplanService } from '../docplan.service';
+import { EcgPickerComponent } from '../ecg-picker/ecg-picker.component';
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-docplan-research',
@@ -18,6 +23,10 @@ import { MatSelectModule } from '@angular/material/select';
     ReactiveFormsModule,
     MatFormFieldModule,
     MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatDialogModule,
   ],
   templateUrl: './docplan-research.component.html',
   styleUrl: './docplan-research.component.scss',
@@ -32,6 +41,7 @@ export class DocplanResearchComponent implements OnInit {
 
   public selectors: Selector[] = [];
   private research: DocplanService = inject(DocplanService);
+  private dialog: MatDialog = inject(MatDialog);
 
   public selectorsError: boolean = false;
 
@@ -80,5 +90,14 @@ export class DocplanResearchComponent implements OnInit {
         },
       },
     ]);
+  }
+
+  openEcgManager(): void {
+    this.dialog.open(EcgPickerComponent, {
+      minWidth: '550px',
+      maxWidth: '90vw',
+      maxHeight: '80vh',
+      hasBackdrop: true,
+    });
   }
 }

--- a/src/app/sites/docplan/ecg-picker/ecg-picker.component.html
+++ b/src/app/sites/docplan/ecg-picker/ecg-picker.component.html
@@ -43,8 +43,25 @@
           <mat-cell *matCellDef="let ecg">
             <button mat-stroked-button color="primary"
                     type="button"
+                    *ngIf="isPickerMode"
                     (click)="select(ecg)">
               Définir
+            </button>
+          </mat-cell>
+        </ng-container>
+
+        <ng-container matColumnDef="delete">
+          <mat-header-cell *matHeaderCellDef></mat-header-cell>
+          <mat-cell *matCellDef="let ecg">
+            <button mat-icon-button
+                    type="button"
+                    [color]="ecg.nom ? '' : 'warn'"
+                    [disabled]="!!ecg.nom"
+                    [matTooltip]="ecg.nom
+                      ? 'Suppression impossible — utilisée par : ' + ecg.nom
+                      : 'Supprimer cette entité cohérente'"
+                    (click)="deleteEcg(ecg)">
+              <mat-icon>delete</mat-icon>
             </button>
           </mat-cell>
         </ng-container>

--- a/src/app/sites/docplan/ecg-picker/ecg-picker.component.scss
+++ b/src/app/sites/docplan/ecg-picker/ecg-picker.component.scss
@@ -27,6 +27,10 @@
   white-space: normal;
 }
 
+button[disabled] mat-icon {
+  color: rgba(0, 0, 0, 0.26);
+}
+
 .no-data {
   color: rgba(0, 0, 0, 0.5);
   font-style: italic;

--- a/src/app/sites/docplan/ecg-picker/ecg-picker.component.ts
+++ b/src/app/sites/docplan/ecg-picker/ecg-picker.component.ts
@@ -1,12 +1,13 @@
-import { Component, OnInit, ChangeDetectorRef, inject } from '@angular/core';
+import { Component, OnInit, ChangeDetectorRef, inject, Optional, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { EntiteCoherente } from '../../site-detail/detail-gestion/docplan';
 import { SitesService } from '../../sites.service';
 import { FormService } from '../../../shared/services/form.service';
+import { ConfirmationService } from '../../../shared/services/confirmation.service';
 
-import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatDialogRef, MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -38,18 +39,28 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 export class EcgPickerComponent implements OnInit {
   entites: EntiteCoherente[] = [];
   dataSource!: MatTableDataSource<EntiteCoherente>;
-  displayedColumns: string[] = ['nom_ecg', 'sites', 'action'];
+  displayedColumns: string[] = ['nom_ecg', 'sites', 'action', 'delete'];
 
   isLoading = true;
   isCreating = false;
   ecgForm!: FormGroup;
 
+  // true = ouvert depuis une fiche PG pour sélectionner une ECG
+  // false = ouvert depuis /docplan pour gérer les ECG
+  isPickerMode: boolean;
+
   private sitesService = inject(SitesService);
   private formService = inject(FormService);
+  private confirmationService = inject(ConfirmationService);
   private snackBar = inject(MatSnackBar);
   private cdr = inject(ChangeDetectorRef);
 
-  constructor(private dialogRef: MatDialogRef<EcgPickerComponent>) {}
+  constructor(
+    private dialogRef: MatDialogRef<EcgPickerComponent>,
+    @Optional() @Inject(MAT_DIALOG_DATA) data: { uuid_doc: string } | null
+  ) {
+    this.isPickerMode = !!data?.uuid_doc;
+  }
 
   async ngOnInit() {
     try {
@@ -81,21 +92,53 @@ export class EcgPickerComponent implements OnInit {
     this.isCreating = false;
   }
 
+  deleteEcg(ecg: EntiteCoherente): void {
+    this.confirmationService
+      .confirm(
+        'Suppression',
+        `Supprimer l'entité cohérente de gestion "<strong>${ecg.nom_ecg}</strong>" ?<br><strong>Cette action est irréversible.</strong>`,
+        'delete'
+      )
+      .subscribe((ok) => {
+        if (!ok) return;
+        this.sitesService.deleteEntiteCoherente(ecg.uuid_ecg).subscribe({
+          next: () => {
+            this.entites = this.entites.filter(e => e.uuid_ecg !== ecg.uuid_ecg);
+            this.dataSource = new MatTableDataSource(this.entites);
+            this.snackBar.open('Entité cohérente supprimée', 'Fermer', {
+              duration: 3000,
+              panelClass: ['snackbar-success'],
+            });
+            this.cdr.detectChanges();
+          },
+          error: (err) => console.error('Erreur suppression ECG', err),
+        });
+      });
+  }
+
   saveCreate(): void {
     if (!this.ecgForm.valid) return;
 
+    const newEcg: EntiteCoherente = {
+      uuid_ecg: this.ecgForm.value.uuid_ecg,
+      nom_ecg: this.ecgForm.value.nom,
+      nom: null,
+    };
+
     this.sitesService.insertTable('docplan_entites_coherentes', this.ecgForm.value).subscribe({
       next: () => {
-        const newEcg: EntiteCoherente = {
-          uuid_ecg: this.ecgForm.value.uuid_ecg,
-          nom_ecg: this.ecgForm.value.nom,
-          nom: null,
-        };
         this.snackBar.open('Entité cohérente créée', 'Fermer', {
           duration: 3000,
           panelClass: ['snackbar-success'],
         });
-        this.dialogRef.close(newEcg);
+        if (this.isPickerMode) {
+          this.dialogRef.close(newEcg);
+        } else {
+          this.entites = [...this.entites, newEcg];
+          this.dataSource = new MatTableDataSource(this.entites);
+          this.isCreating = false;
+          this.cdr.detectChanges();
+        }
       },
       error: (err) => console.error('Erreur création ECG', err),
     });

--- a/src/app/sites/site-detail/detail-gestion/detail-gestion.component.ts
+++ b/src/app/sites/site-detail/detail-gestion/detail-gestion.component.ts
@@ -13,7 +13,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { Overlay } from '@angular/cdk/overlay';
 
 @Component({
   selector: 'app-detail-gestion',
@@ -46,7 +45,6 @@ export class DetailGestionComponent implements AfterViewInit {
 
   constructor(
     private dialog: MatDialog,
-    private overlay: Overlay
   ) {}
 
   ngAfterViewInit(): void {
@@ -102,7 +100,6 @@ export class DetailGestionComponent implements AfterViewInit {
       backdropClass: 'custom-backdrop-gerer',
       enterAnimationDuration: '400ms',
       exitAnimationDuration: '300ms',
-      scrollStrategy: this.overlay.scrollStrategies.close(),
     });
 
     dialogRef.afterClosed().subscribe(() => {

--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.html
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.html
@@ -178,6 +178,13 @@
         <span class="ecg-nom">{{ ecgCourante.nom_ecg }}</span>
         <span class="ecg-sites" *ngIf="ecgCourante.nom">Sites : {{ ecgCourante.nom }}</span>
       </div>
+      <button mat-icon-button color="warn"
+              type="button"
+              *ngIf="isEditMode"
+              matTooltip="Retirer l'entité cohérente de gestion"
+              (click)="removeEcg()">
+        <mat-icon>link_off</mat-icon>
+      </button>
     </div>
 
     <ng-template #noEcg>

--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.scss
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.scss
@@ -120,7 +120,7 @@ mat-dialog-content.dialogue {
 
 .ecg-courante {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 12px;
   padding: 12px 16px;
   background-color: #eaf4fb;
@@ -133,6 +133,7 @@ mat-dialog-content.dialogue {
   }
 
   .ecg-info {
+    flex: 1;
     display: flex;
     flex-direction: column;
     gap: 4px;

--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.ts
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.ts
@@ -28,7 +28,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Overlay } from '@angular/cdk/overlay';
 
 @Component({
   selector: 'app-docplan-fiche',
@@ -75,7 +74,6 @@ export class DocPlanFicheComponent implements OnInit, OnDestroy {
   constructor(
     private dialogRef: MatDialogRef<DocPlanFicheComponent>,
     private dialog: MatDialog,
-    private overlay: Overlay,
     private sitesService: SitesService,
     private formService: FormService,
     private confirmationService: ConfirmationService,
@@ -193,11 +191,10 @@ export class DocPlanFicheComponent implements OnInit, OnDestroy {
 
   openEcgPicker(): void {
     const dialogRef = this.dialog.open(EcgPickerComponent, {
-      minWidth: '550px',
+      minWidth: '450px',
       maxWidth: '90vw',
       maxHeight: '80vh',
       hasBackdrop: true,
-      scrollStrategy: this.overlay.scrollStrategies.close(),
     });
 
     dialogRef.afterClosed().subscribe((ecg: EntiteCoherente | undefined) => {
@@ -207,5 +204,11 @@ export class DocPlanFicheComponent implements OnInit, OnDestroy {
         this.cdr.detectChanges();
       }
     });
+  }
+
+  removeEcg(): void {
+    this.ecgCourante = undefined;
+    this.docPlanForm.patchValue({ entite_coherente: null });
+    this.cdr.detectChanges();
   }
 }

--- a/src/app/sites/sites.service.ts
+++ b/src/app/sites/sites.service.ts
@@ -87,6 +87,16 @@ export class SitesService {
     );
   }
 
+  deleteEntiteCoherente(uuid_ecg: string): Observable<any> {
+    const url = `${this.activeUrl}delete/docplan_entites_coherentes/uuid_ecg=${uuid_ecg}`;
+    return this.http.delete<any>(url).pipe(
+      catchError(error => {
+        console.error('Erreur lors de la suppression de l\'entité cohérente', error);
+        throw error;
+      })
+    );
+  }
+
   async getMilNat(subroute: string): Promise<MilNat[]> {
     return this.getData<MilNat[]>(subroute);
   }


### PR DESCRIPTION
- Correction fermeture intempestive des dialogs : suppression du scrollStrategy close() sur les ouvertures de DocPlanFicheComponent et EcgPickerComponent
- EcgPickerComponent : mode automatique picker/gestion selon présence de MAT_DIALOG_DATA — bouton "Définir" masqué en mode gestion, création reste dans la liste au lieu de fermer
- EcgPickerComponent : suppression d'ECG avec ConfirmationService, poubelle grisée + tooltip contextuel si l'ECG est utilisée par des sites
- SitesService : ajout de deleteEntiteCoherente()
- docplan-research : bouton d'accès au gestionnaire ECG (account_tree), layout flex avec filtres à gauche et bouton ECG à droite
- docplan-fiche : bouton removeEcg() pour retirer l'ECG assignée