### PR TITLE
fix(scss): restaurer la palette \$custom-proteger perdue lors du conf…

### DIFF
--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.html
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.html
@@ -21,6 +21,14 @@
       <h2 *ngIf="!isNewDoc && !isEditMode">Document planificateur</h2>
       <h2 *ngIf="!isNewDoc && isEditMode">Modification du document planificateur</h2>
     </div>
+
+    <button mat-icon-button color="warn"
+            type="button"
+            *ngIf="!isNewDoc"
+            matTooltip="Supprimer ce document planificateur"
+            (click)="deleteItemConfirm()">
+      <mat-icon>delete</mat-icon>
+    </button>
   </div>
 
   <!-- ==============================

--- a/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.ts
+++ b/src/app/sites/site-detail/detail-gestion/docplan-fiche/docplan-fiche.component.ts
@@ -211,4 +211,28 @@ export class DocPlanFicheComponent implements OnInit, OnDestroy {
     this.docPlanForm.patchValue({ entite_coherente: null });
     this.cdr.detectChanges();
   }
+
+  deleteItemConfirm(): void {
+    const nom = this.docPlanDetail?.nom || 'ce document planificateur';
+    this.confirmationService
+      .confirm(
+        'Confirmation de suppression',
+        `Voulez-vous vraiment supprimer "<strong>${nom}</strong>" ?<br><strong>Cette action est irréversible.</strong>`,
+        'delete'
+      )
+      .subscribe(result => {
+        if (result) {
+          this.sitesService.deleteDocPlan(this.docPlanDetail!.uuid_doc).subscribe({
+            next: () => {
+              this.snackBar.open('Document planificateur supprimé', 'Fermer', {
+                duration: 3000,
+                panelClass: ['snackbar-success'],
+              });
+              this.dialogRef.close(true);
+            },
+            error: (err) => console.error('Erreur suppression document planificateur', err),
+          });
+        }
+      });
+  }
 }

--- a/src/app/sites/sites.service.ts
+++ b/src/app/sites/sites.service.ts
@@ -87,6 +87,16 @@ export class SitesService {
     );
   }
 
+  deleteDocPlan(uuid_doc: string): Observable<any> {
+    const url = `${this.activeUrl}delete/docplan_documents/uuid_doc=${uuid_doc}`;
+    return this.http.delete<any>(url).pipe(
+      catchError(error => {
+        console.error('Erreur lors de la suppression du document planificateur', error);
+        throw error;
+      })
+    );
+  }
+
   deleteEntiteCoherente(uuid_ecg: string): Observable<any> {
     const url = `${this.activeUrl}delete/docplan_entites_coherentes/uuid_ecg=${uuid_ecg}`;
     return this.http.delete<any>(url).pipe(

--- a/src/app/styles/themes.scss
+++ b/src/app/styles/themes.scss
@@ -61,6 +61,40 @@ $custom-red: (
   )
 );
 
+// Palette orange pour "proteger" basée sur la couleur $couleur-faune
+$custom-proteger: (
+  50: lighten($orangeC, 15%),
+  100: $orangeC,
+  200: lighten($orangeM, 5%),
+  300: $orangeM,
+  400: darken($orangeM, 5%),
+  500: $proteger,
+  600: darken($proteger, 10%),
+  700: darken($proteger, 20%),
+  800: darken($proteger, 30%),
+  900: darken($proteger, 40%),
+  A100: $orangeC,
+  A200: $orangeM,
+  A400: $proteger,
+  A700: darken($proteger, 15%),
+  contrast: (
+    50: rgba(black, 0.87),
+    100: rgba(black, 0.87),
+    200: rgba(black, 0.87),
+    300: rgba(white, 0.87),
+    400: rgba(white, 0.87),
+    500: white,
+    600: white,
+    700: white,
+    800: white,
+    900: white,
+    A100: rgba(black, 0.87),
+    A200: rgba(white, 0.87),
+    A400: white,
+    A700: white,
+  )
+);
+
 // Palette bleue basée sur $connaitre ($bleuC / $bleuM / $bleuF)
 $custom-connaitre: (
   50:  lighten($bleuC, 18%),
@@ -91,6 +125,7 @@ $custom-connaitre: (
 $gerer-palette: mat.m2-define-palette($custom-gerer);
 $connaitre-palette: mat.m2-define-palette($custom-connaitre, 500, 300, 700);
 $red-palette: mat.m2-define-palette($custom-red);
+$proteger-palette: mat.m2-define-palette($custom-proteger);
 
 // Thème associé à la palette gerer
 $gerer-theme: mat.m2-define-light-theme((


### PR DESCRIPTION
…lit de merge

La map \$custom-proteger et \$proteger-palette avaient disparu de themes.scss suite à un conflit mal résolu sur la branche main, cassant le build de production.

feat(docplan): ajouter le bouton de suppression d'un document planificateur