### PR TITLE
fix(foncier-mfu): corriger le décalage du fond à l'ouverture de la bo…

### DIFF
--- a/src/app/sites/foncier/fon-pmfu/fon-pmfu.component.ts
+++ b/src/app/sites/foncier/fon-pmfu/fon-pmfu.component.ts
@@ -169,7 +169,7 @@ export class FonPmfuComponent implements OnInit, AfterViewInit {
         enterAnimationDuration: '400ms',
         exitAnimationDuration: '300ms',
 
-        scrollStrategy: this.overlay.scrollStrategies.block(),
+        scrollStrategy: this.overlay.scrollStrategies.close(), // ✅ Résout le décalage du fond (ne ferme pas car scroll interne)
       });
       dialogRef.afterClosed().subscribe((result) => {
         console.log('La fenetre de dialogue vient de se fermer');
@@ -187,7 +187,7 @@ export class FonPmfuComponent implements OnInit, AfterViewInit {
         enterAnimationDuration: '400ms',
         exitAnimationDuration: '300ms',
 
-        scrollStrategy: this.overlay.scrollStrategies.block(),
+        scrollStrategy: this.overlay.scrollStrategies.close(), // ✅ Résout le décalage du fond (ne ferme pas car scroll interne)
       });
       dialogRef.afterClosed().subscribe((result) => {
         console.log('La fenetre de dialogue vient de se fermer');


### PR DESCRIPTION
…îte de dialogue projet MFU

Utilise scrollStrategies.close() au lieu de block(), comme déjà fait pour la boîte de dialogue projet (detail-projets.component.ts).