### PR TITLE
feat(projets): carte leaflet des opérations dans le bilan de projet

### DIFF
--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -53,6 +53,7 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() selectParcellesMode: boolean = false; // Active le mode sélection de parcelles
   @Input() coucheSitesCenca: string = 'cenca_autres'; // Nom de la couche à charger
   @Input() zoomOnParcelleAdd: boolean = false; // Zoom auto lors de l'ajout d'une parcelle
+  @Input() zoomOnOperations: boolean = false; // Zoom sur l'emprise combinée des opérations à l'init
 
   @Input() isEditMode: boolean = false; // Mode édition du parent
 
@@ -509,10 +510,12 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
         
         // Obtenir les limites et ajuster la vue
         const bounds = geojsonLayer.getBounds();
-        // Ajoute un petit délai pour laisser la carte s'afficher avant d'animer le zoom
-        setTimeout(() => {
-          this.map.flyToBounds(bounds, { duration: 3.5 }); // durée en secondes
-        }, 800); // délai en ms
+        // Zoom sur le site sauf si zoomOnOperations est actif (zoom sur opérations prioritaire)
+        if (!this.zoomOnOperations) {
+          setTimeout(() => {
+            this.map.flyToBounds(bounds, { duration: 3.5 });
+          }, 800);
+        }
 
         // Bouton (contrôle) personnalisé pour recentrer la carte sur l'emprise du site
         const ZoomToGeoJsonControl = L.Control.extend({
@@ -553,6 +556,7 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
       // On regarde maintenant si on a des localisations_operations
       if (this.localisations_operations && this.localisations_operations?.length > 0) {
         console.log('Localisations d\'opérations trouvées :', this.localisations_operations.length);
+        let combinedBounds: L.LatLngBounds | null = null;
         for (const loc_ope of this.localisations_operations) {
           console.log('Traitement de la localisation d\'opération :', loc_ope);
           const geojson = loc_ope.geojson;
@@ -586,14 +590,14 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
                     // console.log('NorthEast :', bounds.getNorthEast());
                     // console.log('Center :', bounds.getCenter());
                     // console.log('toBBoxString :', bounds.toBBoxString());
-                    
+
                     const northLat = bounds.getNorthEast().lat;
                     const southLat = bounds.getSouthWest().lat;
                     const westLng = bounds.getSouthWest().lng;
                     const eastLng = bounds.getNorthEast().lng;
                     const middleLng = (westLng + eastLng) / 2;
                     const targetLat = southLat + 0.9 * (northLat - southLat);
-                    
+
                     // Crée un marker invisible pour afficher le label au-dessus du polygone
                     const marker = L.marker([targetLat, middleLng], { opacity: 0 });
                     marker.bindTooltip(
@@ -612,6 +616,10 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
                 fillColor: color,
               }).addTo(this.map);
               geojsonLayer.bringToFront();
+              if (this.zoomOnOperations) {
+                const lb = geojsonLayer.getBounds();
+                combinedBounds = combinedBounds ? combinedBounds.extend(lb) : lb;
+              }
 
             } else if (geometryType === 'LineString' || geometryType === 'MultiLineString') {
               const geojsonLayer = L.geoJSON(geojson, {
@@ -626,7 +634,7 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
                     `Longueur : ${length}`,
                     { permanent: true, direction: 'center' }
                   );
-                  
+
                 }
               }); // Fin de la création de geojsonLayer
               const color = this.getRandomColorName();
@@ -636,6 +644,10 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
                 opacity: 1,
               }).addTo(this.map);
               geojsonLayer.bringToFront();
+              if (this.zoomOnOperations) {
+                const lb = geojsonLayer.getBounds();
+                combinedBounds = combinedBounds ? combinedBounds.extend(lb) : lb;
+              }
 
             } else if (geometryType === 'Point' || geometryType === 'MultiPoint') {
               const geojsonLayer = L.geoJSON(geojson, {
@@ -647,10 +659,19 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
                 }
               }).addTo(this.map);
               geojsonLayer.bringToFront();
+              if (this.zoomOnOperations) {
+                const lb = geojsonLayer.getBounds();
+                combinedBounds = combinedBounds ? combinedBounds.extend(lb) : lb;
+              }
             } else {
               console.warn('Localisation d\'opération invalide ou sans GeoJSON :', loc_ope);
             }
           }
+        }
+        if (this.zoomOnOperations && combinedBounds && combinedBounds.isValid()) {
+          setTimeout(() => {
+            this.map.flyToBounds(combinedBounds!, { duration: 3.5 });
+          }, 800);
         }
       } else {
         // Sinon on zoom sur la Champagne-Ardenne

--- a/src/app/sites/site-detail/detail-projets/projet/operation/operation.component.html
+++ b/src/app/sites/site-detail/detail-projets/projet/operation/operation.component.html
@@ -442,11 +442,16 @@ Variable (operation) form: {{ form }}<br>
       </form>
     </mat-step>
 
-    <mat-step [stepControl]="form!" *ngIf="operation !== undefined && operation !== null">
+    <mat-step [stepControl]="form!">
       <ng-template matStepLabel>Données spatiales</ng-template>
 
+      <!-- Nouveau formulaire : pas encore d'enregistrement -->
+      <div *ngIf="!operation">
+        <p><em>La localisation sera à renseigner après le premier enregistrement de cette fiche.</em></p>
+      </div>
+
       <!-- Quand une localisation existe -->
-      <div *ngIf="operation.localisations !== undefined && operation.localisations.length > 0">
+      <div *ngIf="operation && operation.localisations !== undefined && operation.localisations.length > 0">
 
         <!-- <div *ngFor="let localisation of operation.localisations">
           <div>
@@ -466,17 +471,12 @@ Variable (operation) form: {{ form }}<br>
         </div>
       </div>
 
-      <div *ngIf="!operation.localisations || operation.localisations.length === 0">
-        Il n'y a pas encore de localisation enregistrée pour cette opération. 
-      </div>
-      
-      
-      <div *ngIf="isAddOperation">
-        Merci de terminer cette saisie de nouvel objectif avant d'ajouter une emprise de travaux.
+      <div *ngIf="operation && (!operation.localisations || operation.localisations.length === 0)">
+        Il n'y a pas encore de localisation enregistrée pour cette opération.
       </div>
 
       <!-- Pour uploader une localisation -->
-      <div *ngIf="isEditOperation && operation.localisations === undefined || operation.localisations !== undefined && operation.localisations.length == 0">
+      <div *ngIf="operation && (isEditOperation && operation.localisations === undefined || operation.localisations !== undefined && operation.localisations.length == 0)">
         <button mat-button (click)="downloadShapefileExample('polygone')">Télécharger le modèle de fichier shapefile de type POLYGONE si necessaire</button>
         <button mat-button (click)="downloadShapefileExample('ligne')">Télécharger le modèle de fichier shapefile de type LIGNE si necessaire</button>
         <button mat-button (click)="downloadShapefileExample('point')">Télécharger le modèle de fichier shapefile de type POINT si necessaire</button>

--- a/src/app/sites/site-detail/detail-projets/projet/projet.component.html
+++ b/src/app/sites/site-detail/detail-projets/projet/projet.component.html
@@ -392,6 +392,17 @@
               </tbody>
             </table>
           </div>
+
+          <div class="bilan-section" *ngIf="localisations_operations_projet.length > 0">
+            <div class="bilan-section-titre">CARTE DES OPÉRATIONS</div>
+            <app-map
+              mapName="Opérations du projet"
+              [localisation_site]="projetLite.localisation_site"
+              [localisations_operations]="localisations_operations_projet"
+              [zoomOnOperations]="true">
+            </app-map>
+          </div>
+
         </ng-container>
         <!-- <button mat-button type="submit">SOUMETTRE</button> -->
       </form>

--- a/src/app/sites/site-detail/detail-projets/projet/projet.component.ts
+++ b/src/app/sites/site-detail/detail-projets/projet/projet.component.ts
@@ -8,6 +8,7 @@ import { ProjetLite, Projet } from '../projets';
 import { OperationLite } from './operation/operations';
 import { Objectif } from './objectif/objectifs';
 import { SelectValue } from '../../../../shared/interfaces/formValues';
+import { Localisation } from '../../../../shared/interfaces/localisation';
 
 import { ProjetService, DeleteItemTypeEnum } from '../projets.service';
 import { FormService } from '../../../../shared/services/form.service';
@@ -49,7 +50,7 @@ import { BreakpointObserver } from '@angular/cdk/layout';
 
 import { ObjectifComponent } from './objectif/objectif.component';
 import { OperationComponent } from './operation/operation.component';
-// import { MapComponent } from '../../../../map/map.component';
+import { MapComponent } from '../../../../map/map.component';
 
 // import { Projection } from 'leaflet';
 // NE PAS oublier de décommenter la
@@ -92,7 +93,7 @@ export const MY_DATE_FORMATS = {
     FormButtonsComponent,
     // DetailGestionComponent,
     CommonModule,
-    // MapComponent,
+    MapComponent,
     MatSlideToggleModule,
     MatDialogModule,
     // MatDialogTitle,
@@ -124,8 +125,9 @@ export class ProjetComponent implements OnInit, OnDestroy  { // Implements OnIni
 
   projetLite: ProjetLite;
   projet!: Projet;
-  objectifs_bilan: Objectif[] = []; // Liste des objectifs associés au projet
-  operations_bilan: OperationLite[] = []; // Liste des opérations associées au projet
+  objectifs_bilan: Objectif[] = [];
+  operations_bilan: OperationLite[] = [];
+  localisations_operations_projet: Localisation[] = [];
   isLoading: boolean = true;  // Initialisation à 'true' pour activer le spinner
   loadingDelay: number = 400;
 
@@ -276,7 +278,7 @@ export class ProjetComponent implements OnInit, OnDestroy  { // Implements OnIni
           // Assigner l'objet projet directement et forcer le type Projet
           this.projet = await this.fetch('projets', this.projetLite.uuid_proj, this.getTypeInterv(this.projetLite.generation)) as Projet;
           this.operations_bilan = await this.fetch('operations', this.projetLite.uuid_proj) as OperationLite[];
-          console.log('Operations_bilan après extraction :', this.operations_bilan);
+          this.localisations_operations_projet = await this.projetService.getOperationsGeoJson(this.projetLite.uuid_proj);
 
           this.objectifs_bilan = await this.fetch('objectifs', this.projetLite.uuid_proj) as Objectif[];
           console.log('Objectifs_bilan après extraction :', this.objectifs_bilan);

--- a/src/app/sites/site-detail/detail-projets/projets.service.ts
+++ b/src/app/sites/site-detail/detail-projets/projets.service.ts
@@ -60,6 +60,23 @@ export class ProjetService {
   }
 
   // OPERATIONS
+  // Retourne les géométries de toutes les opérations d'un projet sous forme de Localisation[]
+  async getOperationsGeoJson(uuid_proj: string): Promise<Localisation[]> {
+    const url = `${this.activeUrl}projets/uuid=${uuid_proj}/operations/geojson`;
+    const data = await fetch(url);
+    const featureCollection = await data.json();
+    if (!featureCollection?.features?.length) return [];
+    return featureCollection.features.map((feature: any) => ({
+      loc_id: feature.properties?.loc_id ?? undefined,
+      loc_date: feature.properties?.loc_date ?? null,
+      geojson: feature,
+      surface: feature.properties?.surface ?? 0,
+      type: feature.properties?.type ?? '',
+      ref_uuid_ope: feature.properties?.uuid_ope ?? undefined,
+      ref_uuid_proj: feature.properties?.uuid_proj ?? undefined,
+    } as Localisation));
+  }
+
   // Utilisé dans operation.component.ts
   async getOperations(subroute: string): Promise<OperationLite[]> {
     const data = await fetch(this.activeUrl + subroute);

--- a/src/app/sites/site-detail/site-detail.component.html
+++ b/src/app/sites/site-detail/site-detail.component.html
@@ -38,7 +38,7 @@
           <app-detail-projets [siteDetailProjet]="siteDetailProjet"> </app-detail-projets>
         </mat-tab>
 
-        <mat-tab label="Gestion">
+        <mat-tab label="Plans de gestion">
           <app-detail-gestion [inputDetail]="siteDetail"> </app-detail-gestion>
         </mat-tab>
 


### PR DESCRIPTION
- Step "Données spatiales" toujours visible dans le stepper opération ; affiche un message si le formulaire est neuf (pas encore d'id)
- Nouvelle méthode getOperationsGeoJson() dans ProjetService (route /projets/uuid/operations/geojson → Localisation[])
- Carte app-map ajoutée dans le step "Bilan d'execution" sous la table, alimentée par les géométries de toutes les opérations du projet
- Nouveau @Input() zoomOnOperations sur MapComponent : flyToBounds progressif sur l'emprise combinée des opérations à l'init, prioritaire sur le zoom site quand activé